### PR TITLE
168 can join when table is full

### DIFF
--- a/pvm/ts/src/engine/texasHoldem.ts
+++ b/pvm/ts/src/engine/texasHoldem.ts
@@ -209,17 +209,19 @@ class TexasHoldemGame implements IPoker {
     }
 
     joinAtSeat(player: Player, seat: number) {
+        // Check if the player is already in the game
         if (this.exists(player.address)) {
             console.log("Player already joined.");
             throw new Error("Player already joined.");
         }
 
-        if (this.getPlayerCount() + 1 >= this._maxPlayers) {
-            // throw new Error("Game full.");
-            console.log("Table full.");
-            return;
+        //ensure the seat is valid
+        if (seat === -1) {
+            console.log(`Table full. Current players: ${this.getPlayerCount()}, Max players: ${this._maxPlayers}`); 
+            throw new Error("Table full."); // This must be thrown
         }
 
+        console.log(`Player ${player.address} joined at seat ${seat}`);
         this._playersMap.set(seat, player);
 
         // if (player.chips < this._minBuyIn) {
@@ -542,14 +544,17 @@ class TexasHoldemGame implements IPoker {
     findNextSeat(): number {
         const maxSeats = this._maxPlayers;
 
+        // Iterate through all seat numbers to find next available (empty) seat
         for (let seatNumber = 1; seatNumber <= maxSeats; seatNumber++) {
             // Check if seat is empty (null) or doesn't exist in the map
             if (!this._playersMap.has(seatNumber) || this._playersMap.get(seatNumber) === null) {
-                return seatNumber;
-            }
+                return seatNumber; // return first available seat.
+            } 
         }
 
-        throw new Error("No available seats.");
+        // If no seats available, return -1 instead of throwing error
+        //This allows `joinAtSeat` to handle full-table scenario.
+        return -1;
     }
 
     // complete round maybe?

--- a/pvm/ts/src/engine/texasHoldem2.test.ts
+++ b/pvm/ts/src/engine/texasHoldem2.test.ts
@@ -47,12 +47,13 @@ describe.only("Texas Holdem Game", () => {
             expect(game.findNextSeat()).toEqual(2);
         });
 
-        it.skip("should throw error when table is full", () => {
-            // 1 based array, so 9 players is the max
-            for (let i = 0; i < 10; i++) {
+        it("should throw error when table is full", () => {
+            for (let i = 1; i <= 9; i++) {
                 game.join2(`0x${i}`, 1000000000000000000000n);
             }
-            expect(() => game.join2("0x9999", 1000000000000000000000n)).toThrow();
+        
+            console.log("✅ Trying to add extra player...");
+            expect(() => game.join2("0x9999", 1000000000000000000000n)).toThrow("Table full.");
         });
     });
 

--- a/pvm/ts/src/engine/texasHoldem2.test.ts
+++ b/pvm/ts/src/engine/texasHoldem2.test.ts
@@ -52,7 +52,7 @@ describe.only("Texas Holdem Game", () => {
                 game.join2(`0x${i}`, 1000000000000000000000n);
             }
         
-            console.log("✅ Trying to add extra player...");
+            console.log(" Trying to add extra player...");
             expect(() => game.join2("0x9999", 1000000000000000000000n)).toThrow("Table full.");
         });
     });


### PR DESCRIPTION
Refactored `joinAtSeat()` to rely solely on `findNextSeat()` for seat availability, removing redundant getPlayerCount() checks.

changed `findNextSeat()` to return -1 if no seats are available, simplified error handling.

added console logs for debugging when a player tries to join a full table.

Test case to check this in texasHoldem2.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced seat-assignment checks so that players cannot join a game more than once and receive immediate, clear feedback when the table is full.
- **Tests**
  - Updated player addition scenarios to reflect the maximum allowed participants, ensuring the game reliably signals when no more players can join.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->