### PR TITLE
fix: add validation to prevent raising when the player's bet equals t…

### DIFF
--- a/pvm/ts/src/engine/actions/raiseAction.ts
+++ b/pvm/ts/src/engine/actions/raiseAction.ts
@@ -18,6 +18,7 @@ class RaiseAction extends BaseAction implements IAction {
         if (largestBet === 0n) throw new Error("Cannot raise when there's been no action.");
         
         const sumBets = this.getSumBets(player.address);
+        if (largestBet === sumBets) throw new Error("Player must bet not raise.");
 
         const minAmount = (lastBet?.amount || 0n) + this.game.bigBlind;
         if (player.chips < minAmount) throw new Error("Player has insufficient chips to raise.");


### PR DESCRIPTION
…he largest bet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced validations for the raise action to enforce proper betting increments.
  - Players will now receive an error if they attempt to raise without increasing their bet, ensuring moves follow the expected betting rules.
  - This update helps maintain a level playing field, reducing ambiguity and promoting fair, consistent gameplay for everyone.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->