### PR TITLE
added '$' symbols to pots, stack, and chips.

### DIFF
--- a/ui/src/components/playPage/Table.tsx
+++ b/ui/src/components/playPage/Table.tsx
@@ -638,7 +638,7 @@ const Table = () => {
                                                 >
                                                     Total Pot:
                                                     <span style={{ fontWeight: "700px" }}>
-                                                        {" "}
+                                                        {" "} $
                                                         {tableDataValues.tableDataPots?.[0] === "0"
                                                             ? "0.00"
                                                             : tableDataValues.tableDataPots
@@ -658,7 +658,7 @@ const Table = () => {
                                                 >
                                                     Main Pot:
                                                     <span style={{ fontWeight: "700px" }}>
-                                                        {" "}
+                                                        {" "}$
                                                         {tableDataValues.tableDataPots?.[0] === "0"
                                                             ? "0.00"
                                                             : Number(ethers.formatUnits(tableDataValues.tableDataPots?.[0] || "0", 18)).toFixed(2)}

--- a/ui/src/components/playPage/common/Badge.tsx
+++ b/ui/src/components/playPage/common/Badge.tsx
@@ -13,7 +13,7 @@ const Badge: React.FC<BadgeProps> = ({ count, value, color }) => {
             <div style={{ backgroundColor: color }} className={"flex items-center justify-center w-6 h-6 text-white text-sm font-bold rounded-full"}>
                 {count}
             </div>
-            <div className="ml-2 text-lg font-semibold text-black flex justify-between ml-auto mr-auto">{formattedValue}</div>
+            <div className="ml-2 text-lg font-semibold text-black flex justify-between ml-auto mr-auto">${formattedValue}</div>
         </div>
     );
 };

--- a/ui/src/components/playPage/common/Chip.tsx
+++ b/ui/src/components/playPage/common/Chip.tsx
@@ -5,9 +5,18 @@ type ChipProps = {
 const Chip: React.FC<ChipProps> = ({ amount }) => {
     if (amount > 0) {
         return (
-            <div className="relative w-[50px] h-[20px] rounded-tl-3xl rounded-tr-xl rounded-bl-3xl rounded-br-xl bg-[#00000054] flex items-center justify-between">
-                <img src={"/cards/chip.svg"} alt="Chip Button" className="absolute w-[20px] h-[auto] left-[-20px]" />
-                <span className="absolute right-[7px] text-[#dbd3d3]">{amount}</span>
+            <div className="relative h-[20px] pl-[10px] pr-[10px] rounded-full bg-[#00000054] flex items-center">
+                <img
+                    src={"/cards/chip.svg"}
+                    alt="Chip Icon"
+                    className="absolute left-[-16px] w-[18px] h-auto"
+                />
+                <span className="text-[#dbd3d3] text-sm font-medium whitespace-nowrap">
+                    ${amount.toLocaleString(undefined, {
+                        minimumFractionDigits: 2,
+                        maximumFractionDigits: 2
+                    })}
+                </span>
             </div>
         );
     }


### PR DESCRIPTION
added '$' symbols to pots, stack, and chips; fix padding for chips—-now scales for larger bets. 

e.g. Below 
![Screenshot 2025-04-02 at 4 37 52 pm](https://github.com/user-attachments/assets/9d6f5432-107c-4a49-9104-4ce46fa56618)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Refined the visual display of monetary values for clearer currency representation.
  - Updated components to consistently display the dollar sign alongside amounts.
  - Enhanced the appearance of key UI elements with improved layout and styling for a more polished look.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->