### PR TITLE
refactor: update call and raise action logic to use largest bet so that big blind has the option to raise in preflop in more than 2 players

### DIFF
--- a/pvm/ts/src/engine/actions/callAction.ts
+++ b/pvm/ts/src/engine/actions/callAction.ts
@@ -47,15 +47,17 @@ class CallAction extends BaseAction implements IAction {
     protected getDeductAmount(player: Player): bigint {
         const lastAction = this.game.getLastRoundAction();
         const sumBets = this.getSumBets(player.address);
-        const amountToCall = lastAction?.amount || this.game.bigBlind;
         
-        // If player has already bet the same or more than needed to call, return 0
-        if (sumBets >= amountToCall) {
+        // Get the largest bet in the current round
+        const largestBet = this.getLargestBet();
+        
+        // If player has already bet the same or more than the largest bet, return 0
+        if (sumBets >= largestBet) {
             return 0n;
         }
         
         // Otherwise return the difference needed to call
-        return amountToCall - sumBets;
+        return largestBet - sumBets;
     }
 }
 

--- a/pvm/ts/src/engine/actions/raiseAction.ts
+++ b/pvm/ts/src/engine/actions/raiseAction.ts
@@ -1,4 +1,4 @@
-import { PlayerActionType } from "@bitcoinbrisbane/block52";
+import { PlayerActionType, TexasHoldemRound } from "@bitcoinbrisbane/block52";
 import { Player } from "../../models/player";
 import BaseAction from "./baseAction";
 import { IAction, Range } from "../types";
@@ -18,7 +18,16 @@ class RaiseAction extends BaseAction implements IAction {
         if (largestBet === 0n) throw new Error("Cannot raise when there's been no action.");
         
         const sumBets = this.getSumBets(player.address);
-        if (largestBet === sumBets) throw new Error("Player must bet not raise.");
+        
+        // Special case: Allow big blind to raise in pre-flop
+        const playerSeatNumber = this.game.getPlayerSeatNumber(player.address);
+        const isPlayerBigBlind = this.game.bigBlindPosition === playerSeatNumber;
+        const isPreflop = this.game.currentRound === TexasHoldemRound.PREFLOP;
+        
+        // Only throw error if not big blind in pre-flop
+        if (largestBet === sumBets && !(isPlayerBigBlind && isPreflop)) {
+            throw new Error("Player must bet not raise.");
+        }
 
         const minAmount = (lastBet?.amount || 0n) + this.game.bigBlind;
         if (player.chips < minAmount) throw new Error("Player has insufficient chips to raise.");
@@ -26,34 +35,15 @@ class RaiseAction extends BaseAction implements IAction {
         return { minAmount: minAmount, maxAmount: player.chips };
     }
 
-    execute(player: Player, amount: bigint): void {
-        // First verify the action
-        const range = this.verify(player);
-        
-        // Check if the amount is valid
-        if (!range) throw new Error("Invalid raise action.");
-        if (amount < range.minAmount) throw new Error(`Raise amount ${amount} is less than minimum ${range.minAmount}.`);
-        if (amount > range.maxAmount) throw new Error(`Raise amount ${amount} is more than maximum ${range.maxAmount}.`);
+    protected getDeductAmount(player: Player, amount?: bigint): bigint {
+        if (!amount) return 0n;
         
         // Calculate how much more the player needs to add to the pot
         const currentBet = this.getSumBets(player.address);
         const toAdd = amount - currentBet;
         
-        // Ensure player has enough chips
-        if (toAdd > player.chips) {
-            throw new Error(`Player only has ${player.chips} chips, cannot deduct ${toAdd}.`);
-        }
-        
-        // Deduct from player's stack directly
-        player.chips -= toAdd;
-        
-        // Add the action to the game
-        const round = this.game.currentRound;
-        this.game.addAction({ playerId: player.address, action: PlayerActionType.RAISE, amount }, round);
-    }
-
-    protected getDeductAmount(player: Player, amount: bigint): bigint {
-        return player.chips < amount ? player.chips : amount;
+        // Return the amount to add (or player's entire stack if they don't have enough)
+        return toAdd > player.chips ? player.chips : toAdd;
     }
 }
 


### PR DESCRIPTION
- [x] remove unnecessary execute in raiseAction.ts because realised it's implemented in baseAction.ts
- [x]] modified verify method in raiseAction.ts to check for special case to Allow big blind to raise in pre-flop
- [x]] updated getDeductAmount() to superseed base method

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated call functionality: Players now have call amounts determined by the highest wager in the current round for a more consistent betting experience.
  - Enhanced raise mechanics: Players can benefit from refined raise rules, including special pre-flop conditions for big blind players, along with a clearer calculation of additional bet requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->