### PR TITLE
refactor: enhance action verification in CallAction and RaiseAction c…

### DIFF
--- a/pvm/ts/src/engine/actions/callAction.ts
+++ b/pvm/ts/src/engine/actions/callAction.ts
@@ -15,6 +15,10 @@ class CallAction extends BaseAction implements IAction {
         if (lastAction?.amount === 0n || !lastAction?.amount)
             throw new Error("Should check instead.");
 
+        // Check if the last action was a bet or raise
+        if (lastAction.action !== PlayerActionType.BET && lastAction.action !== PlayerActionType.RAISE && lastAction.action !== PlayerActionType.SMALL_BLIND)
+            throw new Error("Last action was not a bet or raise.");
+
         // Get the sum of my bets in this round.
         let deductAmount: bigint = this.getDeductAmount(player);
 

--- a/pvm/ts/src/engine/actions/raiseAction.ts
+++ b/pvm/ts/src/engine/actions/raiseAction.ts
@@ -14,6 +14,16 @@ class RaiseAction extends BaseAction implements IAction {
             throw new Error("Cannot call in the ante round. Small blind must post.");
         }
 
+        if (this.game.currentRound === TexasHoldemRound.PREFLOP) {
+            if (!this.game.getActionsForRound(TexasHoldemRound.PREFLOP).find((action) => action.action === PlayerActionType.SMALL_BLIND)) {
+                throw new Error("Small blind must post before raising.");
+            }
+
+            if (!this.game.getActionsForRound(TexasHoldemRound.PREFLOP).find((action) => action.action === PlayerActionType.BIG_BLIND)) {
+                throw new Error("Big blind must post before raising.");
+            }
+        }
+
         super.verify(player);
 
         const lastBet = this.game.getLastRoundAction();

--- a/pvm/ts/src/engine/texasHoldem-ante-headsup.test.ts
+++ b/pvm/ts/src/engine/texasHoldem-ante-headsup.test.ts
@@ -1,6 +1,6 @@
-import { NonPlayerActionType, PlayerStatus } from "@bitcoinbrisbane/block52";
+import { NonPlayerActionType, PlayerActionType, PlayerStatus } from "@bitcoinbrisbane/block52";
 import TexasHoldemGame from "./texasHoldem";
-import { baseGameConfig, gameOptions, ONE_HUNDRED_TOKENS, TEN_TOKENS } from "./testConstants";
+import { baseGameConfig, gameOptions, ONE_HUNDRED_TOKENS, ONE_TOKEN, TEN_TOKENS } from "./testConstants";
 import { Player } from "../models/player";
 
 // This test suite is for the Texas Holdem game engine, specifically for the Ante round in a heads-up scenario.
@@ -8,18 +8,7 @@ describe("Texas Holdem - Ante - Heads Up", () => {
     describe("Preflop game states", () => {
         let game: TexasHoldemGame;
 
-        const player1 = new Player(
-            "0x1111111111111111111111111111111111111111",
-            undefined,
-            ONE_HUNDRED_TOKENS,
-            undefined,
-            PlayerStatus.ACTIVE
-        );
-
-
         beforeEach(() => {
-            //baseGameConfig.players.push(player1);
-
             game = TexasHoldemGame.fromJson(baseGameConfig, gameOptions);
         });
 
@@ -62,6 +51,18 @@ describe("Texas Holdem - Ante - Heads Up", () => {
             expect(game.exists("0x1fa53E96ad33C6Eaeebff8D1d83c95Fcd7ba9dac")).toBeTruthy();
             expect(game.getPlayer("0x980b8D8A16f5891F41871d878a479d81Da52334c")).toBeDefined();
             expect(game.getPlayer("0x1fa53E96ad33C6Eaeebff8D1d83c95Fcd7ba9dac")).toBeDefined();
+        });
+
+        it("should have correct legal actions after posting the small blind", () => {
+            game.performAction("0x980b8D8A16f5891F41871d878a479d81Da52334c", PlayerActionType.SMALL_BLIND, 2, ONE_TOKEN);
+
+            // Get legal actions for the next player
+            const actual = game.getLegalActions("0x1fa53E96ad33C6Eaeebff8D1d83c95Fcd7ba9dac");
+
+            expect(actual.length).toEqual(3);
+            expect(actual[0].action).toEqual(PlayerActionType.BIG_BLIND);
+            expect(actual[1].action).toEqual(PlayerActionType.FOLD);
+            expect(actual[2].action).toEqual(PlayerActionType.CALL);
         });
     });
 });


### PR DESCRIPTION
Fixes #429 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved validation to ensure that a call action can only follow a bet, raise, or small blind.
	- Added stricter checks to require both small blind and big blind to be posted before allowing a raise in the preflop round.

- **Tests**
	- Enhanced test coverage for heads-up scenarios, verifying available actions after the small blind is posted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->