### PR TITLE
447 implement newcommand on rpcts

### DIFF
--- a/pvm/ts/src/commands/index.ts
+++ b/pvm/ts/src/commands/index.ts
@@ -31,6 +31,7 @@ import { ShutdownCommand } from "./shutdownCommand";
 import { StartServerCommand } from "./startServerCommand";
 import { StopServerCommand } from "./stopServerCommand";
 import { ISignedResponse } from "./interfaces";
+import { NewCommand } from "./newCommand";
 
 export {
     AccountCommand,
@@ -65,5 +66,6 @@ export {
     ShutdownCommand,
     StartServerCommand,
     StopServerCommand,
-    ISignedResponse
+    ISignedResponse,
+    NewCommand
 };

--- a/pvm/ts/src/commands/newCommand.ts
+++ b/pvm/ts/src/commands/newCommand.ts
@@ -8,6 +8,7 @@ import contractSchemas from "../schema/contractSchemas";
 import { ContractSchemaManagement, getContractSchemaManagement } from "../state/contractSchemaManagement";
 import { GameOptions, TexasHoldemRound } from "@bitcoinbrisbane/block52";
 import { TexasHoldemGameState } from "../types";
+import { ZeroHash } from "ethers";
 
 export class NewCommand implements ICommand<ISignedResponse<any>> {
     private readonly gameManagement: GameManagement;
@@ -53,12 +54,12 @@ export class NewCommand implements ICommand<ISignedResponse<any>> {
             if (!game) {
 
                 // Do defaults for the game contract
-                const gameOptions: GameOptions = await this.contractSchemas.getGameOptions(address);
+                const gameOptions: GameOptions = await this.contractSchemas.getGameOptions(this.address);
 
                 if (gameOptions) {
                     const json: TexasHoldemGameState = {
                         type: "cash",
-                        address: address,
+                        address: this.address,
                         minBuyIn: gameOptions.minBuyIn.toString(),
                         maxBuyIn: gameOptions.maxBuyIn.toString(),
                         minPlayers: gameOptions.minPlayers,
@@ -73,10 +74,10 @@ export class NewCommand implements ICommand<ISignedResponse<any>> {
                         nextToAct: -1,
                         round: TexasHoldemRound.ANTE,
                         winners: [],
-                        signature: ethers.ZeroHash
+                        signature: ZeroHash
                     };
 
-                    return json;
+                    return signResult(json, this.privateKey);
                 }
 
             }

--- a/pvm/ts/src/rpc.ts
+++ b/pvm/ts/src/rpc.ts
@@ -20,6 +20,7 @@ import {
     MempoolCommand,
     MineCommand,
     MintCommand,
+    NewCommand,
     PerformActionCommand,
     PurgeMempoolCommand,
     ReceiveMinedBlockHashCommand,
@@ -329,12 +330,17 @@ export class RPC {
                     const [from, to, action, amount, nonce, data] = request.params as RPCRequestParams[RPCMethods.PERFORM_ACTION];
                     const index = Number(data);
                     const _action = action as PlayerActionType | NonPlayerActionType;
-                    const command = new PerformActionCommand(from, to, index, BigInt(amount || "0"), _action, nonce, validatorPrivateKey);
+                    const command = new PerformActionCommand(from, to, index, BigInt(amount || "0"), _action, Number(nonce), validatorPrivateKey);
                     result = await command.execute();
                     break;
                 }
 
-                case RPCMethods.: {
+                case RPCMethods.NEW: {
+                    const [address, seed] = request.params as RPCRequestParams[RPCMethods.NEW];
+                    const command = new NewCommand(address, validatorPrivateKey, seed);
+                    result = await command.execute();
+                    break;
+                }
 
                 case RPCMethods.DEPLOY_CONTRACT: {
                     const [nonce, owner, data] = request.params as RPCRequestParams[RPCMethods.DEPLOY_CONTRACT];

--- a/pvm/ts/src/state/gameManagement.ts
+++ b/pvm/ts/src/state/gameManagement.ts
@@ -7,6 +7,7 @@ import crypto from "crypto";
 import { GameOptions, TexasHoldemRound } from "@bitcoinbrisbane/block52";
 import { ContractSchemaManagement, getContractSchemaManagement } from "./contractSchemaManagement";
 import { Deck } from "../models";
+import { TexasHoldemGameState } from "../types";
 
 export class GameManagement extends StateManager {
     private readonly mempool: Mempool;


### PR DESCRIPTION
Implemented the NewCommand on rpc.ts

Still go these errors. 
![2025-04-26_17-29-07](https://github.com/user-attachments/assets/6bbb1873-9f8e-441b-b4c8-fc5f48300fa8)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for a new RPC method to initialize game state using the NEW command.

- **Bug Fixes**
  - Corrected variable usage in game state initialization to ensure proper assignment of address and signature fields.

- **Refactor**
  - Improved type safety for Texas Hold'em game state management.
  - Updated command handling for more explicit parameter conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->