### PR TITLE
Remove Game Type in top bar

### DIFF
--- a/ui/src/components/playPage/Table.tsx
+++ b/ui/src/components/playPage/Table.tsx
@@ -464,9 +464,6 @@ const Table = () => {
                             </span>
                            
                         </div>
-                        <span className="ml-2 text-[15px]">
-                            Game Type: <span className="text-[15px] text-yellow-400">{tableDataValues.tableDataType}</span>
-                        </span>
                     </div>
 
                     {/* Right Section */}


### PR DESCRIPTION
Game Type removed in top bar

![Screenshot 2025-05-04 at 5 33 46 pm](https://github.com/user-attachments/assets/0c992aa2-a344-4b13-9b0d-753920f84a96)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the display of the game type label and value from the sub-header in the Table component for a cleaner interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->