### PR TITLE
fix: update deck representation based on caller address

### DIFF
--- a/pvm/ts/src/engine/texasHoldem.ts
+++ b/pvm/ts/src/engine/texasHoldem.ts
@@ -1293,7 +1293,7 @@ class TexasHoldemGame implements IPoker, IUpdate {
         }
 
         const pot = this.getPot();
-        const deckAsString = this._deck.toString();
+        const deckAsString = caller === ethers.ZeroAddress ? this._deck.toString() : this._deck.hash;
         const communityCards: string[] = [];
         for (let i = 0; i < this._communityCards.length; i++) {
             communityCards.push(this._communityCards[i].mnemonic);
@@ -1308,7 +1308,6 @@ class TexasHoldemGame implements IPoker, IUpdate {
             bigBlind: this._gameOptions.bigBlind.toString(),
             timeout: this._gameOptions.timeout
         };
-
 
         const state: TexasHoldemStateDTO = {
             type: "cash",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Deck information visibility is now adjusted based on the caller: privileged callers see the full deck, while others see only a hashed version.

- **Style**
  - Minor formatting improvement by removing an unnecessary blank line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->