### PR TITLE
feat: implement leave table functionality with stack management

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,6 @@
       "name": "Debug PVM",
       "type": "node",
       "request": "launch",
-      "runtimeExecutable": "/Users/alexmiller/.nvm/versions/node/v20.18.2/bin/node",
       "runtimeArgs": ["-r", "ts-node/register"],
       "program": "${workspaceFolder}/pvm/ts/src/index.ts",
       "preLaunchTask": "",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,6 +8,7 @@
       "name": "Debug PVM",
       "type": "node",
       "request": "launch",
+      "runtimeExecutable": "/Users/alexmiller/.nvm/versions/node/v20.18.2/bin/node",
       "runtimeArgs": ["-r", "ts-node/register"],
       "program": "${workspaceFolder}/pvm/ts/src/index.ts",
       "preLaunchTask": "",

--- a/ui/src/components/playPage/Table.tsx
+++ b/ui/src/components/playPage/Table.tsx
@@ -38,6 +38,7 @@ import { useCardAnimations } from "../../hooks/useCardAnimations";
 import { useTableData } from "../../hooks/useTableData";
 import { useShowingCardsByAddress } from "../../hooks/useShowingCardsByAddress";
 import { useGameOptions } from "../../hooks/useGameOptions";
+import { useTableLeave } from "../../hooks/playerActions/useTableLeave";
 
 // Enable this to see verbose logging
 const DEBUG_MODE = false;
@@ -109,6 +110,9 @@ const Table = () => {
     
     // Add the useShowingCardsByAddress hook
     const { showingPlayers, isShowdown, refresh: refreshShowingCards } = useShowingCardsByAddress(id);
+    
+    // Add the useTableLeave hook
+    const { leaveTable, isLeaving } = useTableLeave(id);
     
     // Log when cards are being shown
     useEffect(() => {
@@ -466,13 +470,31 @@ const Table = () => {
                                 ) {
                                     alert("You must fold your hand before leaving the table.");
                                 } else {
-                                    console.log("Leaving table with direct reload");
-                                    window.location.href = "/";
+                                    // Get player's current stack if they are seated
+                                    const playerData = tableDataValues.tableDataPlayers?.find(
+                                        (p: any) => p.address?.toLowerCase() === userWalletAddress
+                                    );
+                                    
+                                    if (leaveTable && playerData) {
+                                        console.log("Leaving table via action...");
+                                        leaveTable({ amount: playerData.stack || "0" })
+                                            .then(() => {
+                                                console.log("Successfully left table");
+                                                window.location.href = "/";
+                                            })
+                                            .catch(err => {
+                                                console.error("Error leaving table:", err);
+                                                window.location.href = "/";
+                                            });
+                                    } else {
+                                        console.log("Leaving table with direct reload");
+                                        window.location.href = "/";
+                                    }
                                 }
                             }}
                             title="Return to Lobby"
                         >
-                            Leave Table
+                            {isLeaving ? "Leaving..." : "Leave Table"}
                             <RxExit size={15} />
                         </span>
                     </div>

--- a/ui/src/hooks/playerActions/useTableLeave.ts
+++ b/ui/src/hooks/playerActions/useTableLeave.ts
@@ -4,10 +4,10 @@ import useSWRMutation from "swr/mutation";
 import { PROXY_URL } from "../../config/constants";
 
 interface LeaveTableOptions {
-  amount: string;
-  userAddress: string | null;
-  privateKey: string | null;
-  publicKey: string | null;
+  amount?: string;
+  userAddress?: string | null;
+  privateKey?: string | null;
+  publicKey?: string | null;
   nonce?: string | number;
 }
 
@@ -15,7 +15,11 @@ async function leaveTableFetcher(
   url: string,
   { arg }: { arg: LeaveTableOptions }
 ) {
-  const { amount, userAddress, privateKey, publicKey, nonce = Date.now().toString() } = arg;
+  // Get credentials from localStorage if not provided
+  const userAddress = arg.userAddress || localStorage.getItem("user_eth_public_key");
+  const privateKey = arg.privateKey || localStorage.getItem("user_eth_private_key");
+  const publicKey = arg.publicKey || localStorage.getItem("user_eth_public_key");
+  const { amount = "0", nonce = Date.now().toString() } = arg;
   
   if (!userAddress || !privateKey) {
     throw new Error("Missing user address or private key");
@@ -53,8 +57,14 @@ export function useTableLeave(tableId: string | undefined) {
     leaveTableFetcher
   );
 
+  // Get player's stack from the table data if needed
+  const leaveTableWithStack = async (options: LeaveTableOptions = {}) => {
+    // If no amount was provided, we could fetch the stack here if needed
+    return trigger(options);
+  };
+
   const result = {
-    leaveTable: tableId ? trigger : null,
+    leaveTable: tableId ? leaveTableWithStack : null,
     isLeaving: isMutating,
     error,
     data


### PR DESCRIPTION
leave works on the ui and proxy however we need to fix  this https://github.com/block52/poker-vm/issues/509 to fix leave on the backen. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved the leave table process with asynchronous handling and user feedback, displaying a "Leaving..." indicator while the action completes.
  - The leave table action now checks and processes the player's stack before redirecting.

- **Bug Fixes**
  - Enhanced reliability of the leave table feature by retrieving missing user credentials from local storage if not provided.

- **Chores**
  - Updated debugger configuration to specify the Node.js runtime path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->