### PR TITLE
522 when both check in river it still has a bet option

### DIFF
--- a/pvm/ts/src/engine/actions/betAction.ts
+++ b/pvm/ts/src/engine/actions/betAction.ts
@@ -17,6 +17,10 @@ class BetAction extends BaseAction implements IAction {
             throw new Error("Cannot bet in the ante round.");
         }
 
+        if (this.game.currentRound === TexasHoldemRound.SHOWDOWN) {
+            throw new Error("Cannot bet in the showdown round.");
+        }
+
         // 2. Bet matching check: Player must match existing bets before betting
         const largestBet = this.getLargestBet();
         const sumBets = this.getSumBets(player.address);

--- a/pvm/ts/src/engine/actions/callAction.ts
+++ b/pvm/ts/src/engine/actions/callAction.ts
@@ -15,6 +15,10 @@ class CallAction extends BaseAction implements IAction {
             throw new Error("Call action is not allowed during ante round.");
         }
 
+        if (this.game.currentRound === TexasHoldemRound.SHOWDOWN) {
+            throw new Error("Call action is not allowed during showdown round.");
+        }
+
         // 2. Round-specific checks for preflop
         if (this.game.currentRound === TexasHoldemRound.PREFLOP) {
             // Special case for small blind position in PREFLOP

--- a/pvm/ts/src/engine/actions/callAction.ts
+++ b/pvm/ts/src/engine/actions/callAction.ts
@@ -24,7 +24,14 @@ class CallAction extends BaseAction implements IAction {
                 return { minAmount: amount, maxAmount: amount };
             }
 
-            if (this.game.getPlayerSeatNumber(player.address) === this.game.bigBlindPosition) {
+            // 2. Bet matching check: Get the largest bet and player's current bet
+            // const playerSeat = this.game.getPlayerSeatNumber(player.address);
+            // const isBigBlind = playerSeat === this.game.bigBlindPosition;
+            const largestBet = this.getLargestBet();
+            const playerBet = this.getSumBets(player.address);
+
+            if (this.game.getPlayerSeatNumber(player.address) === this.game.bigBlindPosition && largestBet === playerBet) {
+                // Error message not quite right
                 throw new Error("Big blind cannot call in preflop round.");
             }
         }

--- a/pvm/ts/src/engine/actions/checkAction.ts
+++ b/pvm/ts/src/engine/actions/checkAction.ts
@@ -39,6 +39,10 @@ class CheckAction extends BaseAction implements IAction {
             if (isBigBlind && largestBet === this.game.smallBlind) {
                 return { minAmount: 0n, maxAmount: 0n };
             }
+
+            if (isBigBlind && playerBet < largestBet) {
+                throw new Error("Big blind must call to match the big blind.");
+            }
         }
 
         // 4. General case: Can only check if player has matched the largest bet

--- a/pvm/ts/src/engine/actions/foldAction.ts
+++ b/pvm/ts/src/engine/actions/foldAction.ts
@@ -18,6 +18,12 @@ class FoldAction extends BaseAction implements IAction {
      * @returns A Range object with min and max amount both set to 0 (folding costs nothing)
      */
     verify(player: Player): Range {
+
+        if (this.game.currentRound === TexasHoldemRound.SHOWDOWN) {
+            // Muck cards instead of folding
+            throw new Error("Fold action is not allowed during showdown round.");
+        }
+
         // No status checks needed - allow any player to fold regardless of status
         // This overrides the base verify method which otherwise requires the player to be active
         // and for it to be their turn to act

--- a/pvm/ts/src/engine/testConstants.ts
+++ b/pvm/ts/src/engine/testConstants.ts
@@ -34,7 +34,6 @@ export const defaultPositions: Positions = {
 
 export const baseGameConfig = {
     address: ethers.ZeroAddress,
-    dealer: 0,
     positions: defaultPositions,
     nextToAct: 1,
     currentRound: "ante",

--- a/pvm/ts/src/engine/texasHoldem-ante-headsup.test.ts
+++ b/pvm/ts/src/engine/texasHoldem-ante-headsup.test.ts
@@ -291,8 +291,21 @@ describe("Texas Holdem - Ante - Heads Up", () => {
 
             expect(game.currentRound).toEqual(TexasHoldemRound.SHOWDOWN);
 
+            // Get legal actions for the small blind player
+            actions = game.getLegalActions(SMALL_BLIND_PLAYER);
+            expect(actions.length).toEqual(2); // Muck or Show
+            expect(actions[0].action).toEqual(PlayerActionType.MUCK);
+            expect(actions[1].action).toEqual(PlayerActionType.SHOW);
+
             // Both reveal cards
             game.performAction(SMALL_BLIND_PLAYER, PlayerActionType.SHOW, 13, 0n);
+
+            actions = game.getLegalActions(BIG_BLIND_PLAYER);
+            expect(actions.length).toEqual(2); // Muck or Show
+            expect(actions[0].action).toEqual(PlayerActionType.MUCK);
+            expect(actions[1].action).toEqual(PlayerActionType.SHOW);
+            
+            // Both reveal cards
             game.performAction(BIG_BLIND_PLAYER, PlayerActionType.SHOW, 14, 0n);
 
             expect(game.currentRound).toEqual(TexasHoldemRound.END);

--- a/pvm/ts/src/engine/texasHoldem-ante-headsup.test.ts
+++ b/pvm/ts/src/engine/texasHoldem-ante-headsup.test.ts
@@ -267,9 +267,8 @@ describe("Texas Holdem - Ante - Heads Up", () => {
             expect(actions.length).toEqual(3);
             game.performAction(SMALL_BLIND_PLAYER, PlayerActionType.CALL, 5, ONE_TOKEN);
 
-            // Should be able to check too
             actions = game.getLegalActions(BIG_BLIND_PLAYER);
-            expect(actions.length).toEqual(2);
+            expect(actions.length).toEqual(3);
             game.performAction(BIG_BLIND_PLAYER, PlayerActionType.CHECK, 6, 0n);
 
             expect(game.currentRound).toEqual(TexasHoldemRound.FLOP);

--- a/pvm/ts/src/engine/texasHoldem-preflop.test.ts
+++ b/pvm/ts/src/engine/texasHoldem-preflop.test.ts
@@ -1,0 +1,54 @@
+import { NonPlayerActionType, PlayerActionType, TexasHoldemRound } from "@bitcoinbrisbane/block52";
+import TexasHoldemGame from "./texasHoldem";
+import { baseGameConfig, gameOptions, ONE_HUNDRED_TOKENS, ONE_TOKEN, TWO_TOKENS } from "./testConstants";
+
+// This test suite is for the Texas Holdem game engine, specifically for the Preflop phase in a heads-up game.
+describe("Texas Holdem - Preflop - Heads Up", () => {
+    describe("Preflop game states", () => {
+        const SMALL_BLIND_PLAYER = "0x980b8D8A16f5891F41871d878a479d81Da52334c";
+        const BIG_BLIND_PLAYER = "0x1fa53E96ad33C6Eaeebff8D1d83c95Fcd7ba9dac";
+
+        const THREE_TOKENS = 300000000000000000n;
+
+        let game: TexasHoldemGame;
+
+        beforeEach(() => {
+            game = TexasHoldemGame.fromJson(baseGameConfig, gameOptions);
+            game.performAction(SMALL_BLIND_PLAYER, NonPlayerActionType.JOIN, 0, ONE_HUNDRED_TOKENS);
+            game.performAction(BIG_BLIND_PLAYER, NonPlayerActionType.JOIN, 1, ONE_HUNDRED_TOKENS);
+        });
+
+        it("should have the correct players pre flop", () => {
+            expect(game.getPlayerCount()).toEqual(2);
+
+            expect(game.exists("0x980b8D8A16f5891F41871d878a479d81Da52334c")).toBeTruthy();
+            expect(game.exists("0x1fa53E96ad33C6Eaeebff8D1d83c95Fcd7ba9dac")).toBeTruthy();
+            expect(game.getPlayer("0x980b8D8A16f5891F41871d878a479d81Da52334c")).toBeDefined();
+            expect(game.getPlayer("0x1fa53E96ad33C6Eaeebff8D1d83c95Fcd7ba9dac")).toBeDefined();
+        });
+
+        it("should have correct legal actions after raising the small blind", () => {
+            game.performAction(SMALL_BLIND_PLAYER, PlayerActionType.SMALL_BLIND, 2, ONE_TOKEN);
+            game.performAction(BIG_BLIND_PLAYER, PlayerActionType.BIG_BLIND, 3, TWO_TOKENS);
+            
+            // Add a DEAL action to advance from ANTE to PREFLOP
+            expect(game.currentRound).toEqual(TexasHoldemRound.ANTE);
+            game.performAction(SMALL_BLIND_PLAYER, NonPlayerActionType.DEAL, 4);
+            expect(game.currentRound).toEqual(TexasHoldemRound.PREFLOP);
+            
+            // Now we're in PREFLOP round, so CALL is a valid action
+            game.performAction(SMALL_BLIND_PLAYER, PlayerActionType.RAISE, 5, THREE_TOKENS);
+
+            const nextToAct = game.getNextPlayerToAct();
+            expect(nextToAct).toBeDefined();
+            expect(nextToAct?.address).toEqual(BIG_BLIND_PLAYER);
+
+            const legalActions = game.getLegalActions(BIG_BLIND_PLAYER);
+            expect(legalActions).toEqual([
+                PlayerActionType.CALL,
+                PlayerActionType.RAISE,
+                PlayerActionType.FOLD,
+            ]);
+        });
+    });
+});

--- a/pvm/ts/src/engine/texasHoldem-preflop.test.ts
+++ b/pvm/ts/src/engine/texasHoldem-preflop.test.ts
@@ -44,11 +44,18 @@ describe("Texas Holdem - Preflop - Heads Up", () => {
             expect(nextToAct?.address).toEqual(BIG_BLIND_PLAYER);
 
             const legalActions = game.getLegalActions(BIG_BLIND_PLAYER);
-            expect(legalActions).toEqual([
-                PlayerActionType.CALL,
-                PlayerActionType.RAISE,
-                PlayerActionType.FOLD,
-            ]);
+            expect(legalActions.length).toEqual(3);
+            expect(legalActions).toContainEqual(expect.objectContaining({
+                action: PlayerActionType.CALL
+            }));
+
+            expect(legalActions).toContainEqual(expect.objectContaining({
+                action: PlayerActionType.RAISE
+            }));
+
+            expect(legalActions).toContainEqual(expect.objectContaining({
+                action: PlayerActionType.FOLD
+            }));
         });
     });
 });

--- a/pvm/ts/src/engine/texasHoldem-state.test.ts
+++ b/pvm/ts/src/engine/texasHoldem-state.test.ts
@@ -25,7 +25,7 @@ describe("Texas Holdem - State", () => {
 
             // Game properties
             expect(game.smallBlind).toEqual(100000000000000000n);
-            expect(game.bigBlind).toEqual(2000000000000000000n);
+            expect(game.bigBlind).toEqual(200000000000000000n);
             expect(game.dealerPosition).toEqual(9);
             expect(game.currentPlayerId).toEqual(ethers.ZeroAddress);
             expect(game.currentRound).toEqual(TexasHoldemRound.ANTE);


### PR DESCRIPTION
Merge after #519 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Prevented betting, calling, and folding actions during the showdown round.
	- Improved validation for big blind actions during the preflop round, ensuring correct handling of raises and calls.
- **Tests**
	- Updated existing tests to reflect new validation rules and correct legal actions during gameplay.
	- Added new tests for preflop scenarios in heads-up Texas Holdem games.
- **Chores**
	- Removed an unused property from the base game configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->