### PR TITLE
show hand values in winner dto

### DIFF
--- a/pvm/ts/package.json
+++ b/pvm/ts/package.json
@@ -13,7 +13,7 @@
         "sign": "npx ts-node scripts/sign.ts"
     },
     "dependencies": {
-        "@bitcoinbrisbane/block52": "1.0.111",
+        "@bitcoinbrisbane/block52": "1.0.115",
         "@types/cors": "^2.8.17",
         "@types/node": "^22.10.3",
         "@types/ws": "^8.18.1",

--- a/pvm/ts/yarn.lock
+++ b/pvm/ts/yarn.lock
@@ -278,10 +278,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bitcoinbrisbane/block52@1.0.111":
-  version "1.0.111"
-  resolved "https://registry.yarnpkg.com/@bitcoinbrisbane/block52/-/block52-1.0.111.tgz#f2f0f4dd137f315c8f952cf525ce4647ab4f966a"
-  integrity sha512-e/m31bGalqY1IpqKsKNBFHnlmdXF4NmhbedK5DgCTX3YthBct0Qxem4CJcRsFD2h/8WYL0gkcNSriaFJ3boiQw==
+"@bitcoinbrisbane/block52@1.0.115":
+  version "1.0.115"
+  resolved "https://registry.yarnpkg.com/@bitcoinbrisbane/block52/-/block52-1.0.115.tgz#67093b1143b599a2188a79d0449204b14f3bc4cc"
+  integrity sha512-nr9uh8f5PXNuPA66jSwgtpuExKR2K+awcNAxQCUd4LQW82NRR7RwmOPmppQPj5h19OS9xXhdgWrY5TJc/i8m3A==
   dependencies:
     axios "^1.8.1"
     bigunit "^1.2.5"

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bitcoinbrisbane/block52",
-    "version": "1.0.111",
+    "version": "1.0.115",
     "author": "@bitcoinbrisbane",
     "license": "MIT",
     "description": "SDK for interacting with the Block52 Node",

--- a/sdk/src/types/game.ts
+++ b/sdk/src/types/game.ts
@@ -93,7 +93,10 @@ export type LegalActionDTO = {
 
 export type WinnerDTO = {
     address: string;
-    amount: number;
+    amount: string;
+    cards: string[] | undefined; // Can win with no cards
+    name: string | undefined; // Can win with no cards
+    description: string | undefined; // Can win with no cards
 };
 
 export type PlayerDTO = {


### PR DESCRIPTION
v1.0.113

v1.0.114

Add optional cards and hand properties to WinnerDTO for flexibility in win conditions

v1.0.115

Update dependencies to version 1.0.115 and change WinnerDTO amount type to string

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Winner details in Texas Hold'em games now include hand cards, hand name, and a description, providing richer information about each winner.
- **Improvements**
  - Winner amounts are now represented as strings for greater accuracy.
- **Dependency Updates**
  - Updated the "@bitcoinbrisbane/block52" package to version 1.0.115.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->