### PR TITLE
Add setLastActedSeat method to TexasHoldemGame and update JoinAction …

### DIFF
--- a/pvm/ts/src/engine/actions/joinAction.ts
+++ b/pvm/ts/src/engine/actions/joinAction.ts
@@ -47,6 +47,9 @@ class JoinAction extends BaseAction {
 
         this.game.joinAtSeat(player, seat);
 
+        // Set this seat as the last acted seat to help determine next player
+        this.game.setLastActedSeat(seat);
+
         // Add join action to history without the seat property (it will be added automatically in texasHoldem.ts)
         this.game.addNonPlayerAction(
             {

--- a/pvm/ts/src/engine/texasHoldem-get-next-to-act.test.ts
+++ b/pvm/ts/src/engine/texasHoldem-get-next-to-act.test.ts
@@ -17,15 +17,13 @@ describe("Texas Holdem Game - Next seat", () => {
             game.performAction("0x1fa53E96ad33C6Eaeebff8D1d83c95Fcd7ba9dac", NonPlayerActionType.JOIN, 0, ONE_HUNDRED_TOKENS);
             game.performAction("0x980b8D8A16f5891F41871d878a479d81Da52334c", NonPlayerActionType.JOIN, 1, ONE_HUNDRED_TOKENS);
 
-            // TODO: CHECK THIS LOGIC
             // Verify small blind position
-            // const smallBlindPosition = game.smallBlindPosition;
-            // const smallBlindPlayer = game.getPlayerAtSeat(smallBlindPosition);
+            const smallBlindPosition = game.smallBlindPosition;
+            const smallBlindPlayer = game.getPlayerAtSeat(smallBlindPosition);
 
             // Next player to act should be the small blind
             const nextPlayer = game.getNextPlayerToAct();
-            expect(nextPlayer).toBeUndefined();
-            // expect(nextPlayer?.address).toEqual(smallBlindPlayer?.address);
+            expect(nextPlayer?.address).toEqual(smallBlindPlayer?.address);
         });
 
         it("should return big blind position player after small blind has been posted", () => {

--- a/pvm/ts/src/engine/texasHoldem.ts
+++ b/pvm/ts/src/engine/texasHoldem.ts
@@ -224,6 +224,11 @@ class TexasHoldemGame implements IPoker, IUpdate {
         return this._lastActedSeat;
     }
 
+    
+    setLastActedSeat(seat: number): void {
+        this._lastActedSeat = seat;
+    }
+
     // Game configuration getters
     get minBuyIn(): bigint {
         return this._gameOptions.minBuyIn;


### PR DESCRIPTION
…to utilise it

- Introduced setLastActedSeat method in TexasHoldemGame to manage the last acted seat.
- Updated JoinAction to call setLastActedSeat when a player joins, fixing leaving nextToAct in default state of "-1"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved tracking of the last player to act after joining a seat, ensuring smoother gameplay transitions.
  - Corrected the determination of the next player to act when no blinds have been posted, accurately identifying the small blind player.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->