### PR TITLE
Remove table ID display from the Table component for a cleaner UI.

### DIFF
--- a/ui/src/components/playPage/Table.tsx
+++ b/ui/src/components/playPage/Table.tsx
@@ -841,11 +841,6 @@ const Table = () => {
                 </div>
             )}
 
-            {/* Add table ID display */}
-            <div className="absolute top-24 left-4 text-white bg-black bg-opacity-50 p-2 rounded">
-                Table ID: {id ? id.slice(0, 8) + "..." + id.slice(-6) : "Unknown"}
-            </div>
-
             {/* Powered by Block52 */}
             <div className="fixed bottom-4 left-4 flex items-center z-10 opacity-30">
                 <div className="flex flex-col items-start bg-transparent px-3 py-2 rounded-lg backdrop-blur-sm border-0">


### PR DESCRIPTION
<img width="1247" alt="2025-05-16_13-13-17" src="https://github.com/user-attachments/assets/9d129b36-9577-4168-ac6c-7f117acb4689" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the visual display of the table ID overlay from the play page UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->