### PR TITLE
Update NodeRpcProvider to use import.meta.env.VITE_NODE_RPC_URL for e…

### DIFF
--- a/ui/src/context/NodeRpcContext.tsx
+++ b/ui/src/context/NodeRpcContext.tsx
@@ -24,7 +24,7 @@ interface NodeRpcProviderProps {
 }
 
 // Provider component
-export const NodeRpcProvider: React.FC<NodeRpcProviderProps> = ({ children, nodeUrl = process.env.NODE_RPC_URL || "https://node1.block52.xyz/" }) => {
+export const NodeRpcProvider: React.FC<NodeRpcProviderProps> = ({ children, nodeUrl = import.meta.env.VITE_NODE_RPC_URL || "https://node1.block52.xyz/" }) => {
     const [client, setClient] = useState<IClient | null>(null);
     const [isLoading, setIsLoading] = useState(true);
     const [error, setError] = useState<Error | null>(null);


### PR DESCRIPTION
in order to use VITE_some variable need to use import.meta.env.VITE_NODE_RPC_URL


<img width="725" alt="2025-05-16_14-33-52" src="https://github.com/user-attachments/assets/be0204f8-907b-46ca-8b02-4a132e514e78" />
