### PR TITLE
Add check to prevent folding if player has already folded

### DIFF
--- a/pvm/ts/src/engine/actions/foldAction.ts
+++ b/pvm/ts/src/engine/actions/foldAction.ts
@@ -18,6 +18,12 @@ class FoldAction extends BaseAction implements IAction {
      * @returns A Range object with min and max amount both set to 0 (folding costs nothing)
      */
     verify(player: Player): Range {
+
+        if (player.status === PlayerStatus.FOLDED) {
+            // Player has already folded, no need to fold again
+            throw new Error("Player has already folded.");
+        }
+
         if (this.game.currentRound === TexasHoldemRound.SHOWDOWN) {
             // Muck cards instead of folding
             throw new Error("Fold action is not allowed during showdown round.");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation to prevent players from folding multiple times in a round. An error is now shown if a player attempts to fold after already folding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->