### PR TITLE
685 bug gamestatewinnersamount object object

### DIFF
--- a/pvm/ts/package.json
+++ b/pvm/ts/package.json
@@ -13,7 +13,7 @@
         "sign": "npx ts-node scripts/sign.ts"
     },
     "dependencies": {
-        "@bitcoinbrisbane/block52": "1.0.117",
+        "@bitcoinbrisbane/block52": "1.0.118",
         "@types/cors": "^2.8.17",
         "@types/node": "^22.10.3",
         "@types/ws": "^8.18.1",

--- a/pvm/ts/src/engine/texasHoldem-ante-headsup.test.ts
+++ b/pvm/ts/src/engine/texasHoldem-ante-headsup.test.ts
@@ -313,10 +313,24 @@ describe("Texas Holdem - Ante - Heads Up", () => {
 
             expect(game.currentRound).toEqual(TexasHoldemRound.END);
 
-            // Check the winner
+
+            // Check game states
             const gameState = game.toJson();
+            expect(gameState).toBeDefined();
+            expect(gameState.players).toBeDefined();
+            expect(gameState.players.length).toEqual(2);
+            expect(gameState.communityCards).toBeDefined();
+            expect(gameState.communityCards.length).toEqual(5);
+
+            // Check the winner
             expect(gameState.winners).toBeDefined();
             expect(gameState.winners.length).toEqual(1);
+
+            // Check hole cards
+            expect(gameState.players[0].holeCards).toBeDefined();
+            expect(gameState.players[0].holeCards?.length).toEqual(2);
+            expect(gameState.players[1].holeCards).toBeDefined();
+            expect(gameState.players[1].holeCards?.length).toEqual(2);
 
             // Check players chips
             let smallBlindPlayer = game.getPlayer(SMALL_BLIND_PLAYER);

--- a/pvm/ts/src/engine/texasHoldem-ante-headsup.test.ts
+++ b/pvm/ts/src/engine/texasHoldem-ante-headsup.test.ts
@@ -313,7 +313,6 @@ describe("Texas Holdem - Ante - Heads Up", () => {
 
             expect(game.currentRound).toEqual(TexasHoldemRound.END);
 
-
             // Check game states
             const gameState = game.toJson();
             expect(gameState).toBeDefined();
@@ -325,6 +324,14 @@ describe("Texas Holdem - Ante - Heads Up", () => {
             // Check the winner
             expect(gameState.winners).toBeDefined();
             expect(gameState.winners.length).toEqual(1);
+            expect(gameState.winners[0].address).toEqual(SMALL_BLIND_PLAYER);
+            expect(gameState.winners[0].amount).toEqual("400000000000000000");
+            expect(gameState.winners[0].name).toEqual("Flush");
+            expect(gameState.winners[0].description).toEqual("Flush, Ac High");
+            expect(gameState.winners[0].cards).toBeDefined();
+            expect(gameState.winners[0].cards?.length).toEqual(2);
+            expect(gameState.winners[0].cards?.[0]).toEqual("AC");
+            expect(gameState.winners[0].cards?.[1]).toEqual("3C");
 
             // Check hole cards
             expect(gameState.players[0].holeCards).toBeDefined();

--- a/pvm/ts/src/engine/texasHoldem.ts
+++ b/pvm/ts/src/engine/texasHoldem.ts
@@ -1124,17 +1124,17 @@ class TexasHoldemGame implements IPoker, IUpdate {
 
         // If only one player is active, they win the pot
         if (activePlayers.length === 1) {
+            const hand = hands.get(activePlayers[0].id);
             const _winner: Winner = {
                 amount: this.getPot(),
                 cards: activePlayers[0].holeCards?.map(card => card.mnemonic),
-                name: undefined,
-                description: undefined // Roll these back when description is available from PokerSolver
+                name: hand.name,
+                description: hand.descr // Roll these back when description is available from PokerSolver
             };
 
             this._winners = new Map<string, Winner>();
-            const winner = activePlayers[0];
-            this._winners.set(winner.address, _winner);
-            winner.chips += this.getPot();
+            this._winners.set(activePlayers[0].id, _winner);
+            activePlayers[0].chips += this.getPot();
             return;
         }
 
@@ -1155,7 +1155,7 @@ class TexasHoldemGame implements IPoker, IUpdate {
                     amount: this.getPot(),
                     cards: activePlayers[0].holeCards?.map(card => card.mnemonic),
                     name: hand.name,
-                    description: hand.description
+                    description: hand.descr
                 };
 
                 const winAmount = pot / winnersCount;
@@ -1240,13 +1240,13 @@ class TexasHoldemGame implements IPoker, IUpdate {
         // Prepare winners array
         const winners: WinnerDTO[] = [];
         if (this._winners) {
-            for (const [address, amount] of this._winners.entries()) {
+            for (const [address, winner] of this._winners.entries()) {
                 winners.push({
                     address: address,
-                    amount: amount.toString(),
-                    cards: undefined,
-                    name: undefined,
-                    description: undefined // Roll these back when description is available from PokerSolver
+                    amount: winner.amount.toString(),
+                    cards: winner.cards,
+                    name: winner.name,
+                    description: winner.description
                 });
             }
         }

--- a/pvm/ts/yarn.lock
+++ b/pvm/ts/yarn.lock
@@ -278,10 +278,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bitcoinbrisbane/block52@1.0.117":
-  version "1.0.117"
-  resolved "https://registry.yarnpkg.com/@bitcoinbrisbane/block52/-/block52-1.0.117.tgz#eff1dec8f461f04a2d1ba18f42eefff891a51256"
-  integrity sha512-k2WQmONhCJL1bLPtuELH9faIncWk+TpIqZVT6N4i2Cyvm50UuTA2+SrGGQhdmtxrsKFDGCLx7807zdSs8epV4A==
+"@bitcoinbrisbane/block52@1.0.118":
+  version "1.0.118"
+  resolved "https://registry.yarnpkg.com/@bitcoinbrisbane/block52/-/block52-1.0.118.tgz#e645d5e72984468e14c176ad24b47ea50fe458af"
+  integrity sha512-oGf8I42i2+MMGXggVqyswpu30cB6psE+pyNRPSOSJP6pDCHb7XcRghl5fOkr7Y3hsf6q/OWSAPxbRSFoJ5/Ltg==
   dependencies:
     axios "^1.8.1"
     bigunit "^1.2.5"

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bitcoinbrisbane/block52",
-    "version": "1.0.117",
+    "version": "1.0.118",
     "author": "@bitcoinbrisbane",
     "license": "MIT",
     "description": "SDK for interacting with the Block52 Node",


### PR DESCRIPTION
* fix un-defined
* fix adding pot on default winner
* unit tests

![image](https://github.com/user-attachments/assets/c364bf58-8500-4376-b63c-58eeb9d3a84a)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved winner information in Texas Holdem games to ensure winner details such as hand name and description are accurately displayed after each hand.
- **Tests**
  - Enhanced Texas Holdem end-to-end tests with more comprehensive checks on game state and winner details.
- **Chores**
  - Updated the "@bitcoinbrisbane/block52" dependency to version 1.0.118.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->