### PR TITLE
Enhance footer buttons for sitting in with clearer labels and improve…

### DIFF
--- a/ui/src/components/Footer.tsx
+++ b/ui/src/components/Footer.tsx
@@ -784,15 +784,26 @@ transition-all duration-200 font-medium min-w-[100px]"
                 {isUserInTable && (
                     <div className="fixed bottom-4 right-[30%] flex gap-2 z-20">
                         {isPlayerSittingOut ? (
-                            <button
-                                onClick={handleSitIn}
-                                className="bg-gradient-to-r from-[#2c7873] to-[#1e5954] hover:from-[#1e5954] hover:to-[#0f2e2b] 
-                                text-white font-medium py-1.5 px-4 rounded-lg shadow-md transition-all duration-200 
-                                border border-[#3a9188] hover:border-[#64ffda] flex items-center text-xs"
-                                disabled={isSittingIn}
-                            >
-                                {isSittingIn ? "SITTING IN..." : "I AM BACK"}
-                            </button>
+                            <div className="flex gap-2">
+                                <button
+                                    onClick={handleSitIn}
+                                    className="bg-gradient-to-r from-[#2c7873] to-[#1e5954] hover:from-[#1e5954] hover:to-[#0f2e2b] 
+                                    text-white font-medium py-1.5 px-4 rounded-lg shadow-md transition-all duration-200 
+                                    border border-[#3a9188] hover:border-[#64ffda] flex items-center text-xs"
+                                    disabled={isSittingIn}
+                                >
+                                    {isSittingIn ? "SITTING IN..." : "Wait for Big Blind"}
+                                </button>
+                                <button
+                                    onClick={handleSitIn}
+                                    className="bg-gradient-to-r from-[#2c7873] to-[#1e5954] hover:from-[#1e5954] hover:to-[#0f2e2b] 
+                                    text-white font-medium py-1.5 px-4 rounded-lg shadow-md transition-all duration-200 
+                                    border border-[#3a9188] hover:border-[#64ffda] flex items-center text-xs"
+                                    disabled={isSittingIn}
+                                >
+                                    {isSittingIn ? "SITTING IN..." : "Join Now and Post Big Blind"}
+                                </button>
+                            </div>
                         ) : (
                             <button
                                 onClick={handleSitOut}


### PR DESCRIPTION
…d layout. Added two buttons: "Wait for Big Blind" and "Join Now and Post Big Blind" for better user guidance however they both just move the state to "active"

so I don't think we merge until we know how to handle this.

<img width="983" alt="2025-05-16_17-47-41" src="https://github.com/user-attachments/assets/0a651704-00c9-49c3-a9e3-bae7c65367cd" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the "sit in" state UI to display two side-by-side buttons with distinct labels for joining the game, enhancing clarity for users who are sitting out. Both buttons remain disabled when appropriate.
- **Style**
  - Improved button layout with a flex container and spacing for a cleaner appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->