### PR TITLE
Paige does not reload now when player joints and centralized the vacant player props into the types folder

### DIFF
--- a/ui/src/components/playPage/Players/VacantPlayer.tsx
+++ b/ui/src/components/playPage/Players/VacantPlayer.tsx
@@ -6,13 +6,7 @@ import PokerProfile from "../../../assets/PokerProfile.svg";
 import { toDisplaySeat } from "../../../utils/tableUtils";
 import { useVacantSeatData } from "../../../hooks/useVacantSeatData";
 import { useNodeRpc } from "../../../context/NodeRpcContext";
-
-
-type VacantPlayerProps = {
-    left?: string;
-    top?: string;
-    index: number;
-};
+import type { VacantPlayerProps } from "../../../types/index";
 
 const VacantPlayer: React.FC<VacantPlayerProps> = memo(
     ({ left, top, index }) => {
@@ -71,14 +65,9 @@ const VacantPlayer: React.FC<VacantPlayerProps> = memo(
                 setJoinResponse(response);
                 setJoinSuccess(true);
                 
-                // Close the modal immediately and let the page update naturally via normal data flow
+                // Close the modal immediately
                 setShowConfirmModal(false);
                 
-                // PLACEHOLDER: A future animation could be displayed here before refresh
-                // For now, we just reload the page after a short delay
-                setTimeout(() => {
-                    window.location.reload();
-                }, 300); // Short delay to allow for potential animation
                 
             } catch (err) {
                 console.error("Failed to join table:", err);

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -63,6 +63,7 @@ type Limits = {
     max: string;
 }
 
+//todo tidy up this type
 export type TableStatus = {
     isInTable: boolean;
     isPlayerTurn: boolean;
@@ -85,7 +86,7 @@ export type TableStatus = {
     isSmallBlindPosition: boolean;
 }
 
-
+// Type for PositionArray component props
 export interface PositionArray {
     left?: string;
     top?: string;
@@ -105,4 +106,11 @@ export interface LeaveTableOptions {
 export interface GameWithAddress {
     address: string;
     gameOptions: GameOptionsDTO;
+}
+
+// Type for VacantPlayer component props
+export interface VacantPlayerProps {
+    left?: string;
+    top?: string;
+    index: number;
 }


### PR DESCRIPTION
Paige does not reload now when player joints and centralized the vacant player props into the types folder

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved seat joining experience by closing the confirmation modal immediately after joining, without reloading the page.
- **Documentation**
	- Added and updated comments to clarify the purpose of several type declarations.
- **Chores**
	- Centralized and updated type definitions for component props.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->