### PR TITLE
Remove legacy refresh from use showing cards by address

### DIFF
--- a/ui/src/components/Footer.tsx
+++ b/ui/src/components/Footer.tsx
@@ -34,7 +34,7 @@ const PokerActionPanel: React.FC = () => {
     // Get game state directly from Context - no additional WebSocket connections
     const { gameState } = useGameStateContext();
     const players = gameState?.players || null;
-    const { legalActions, isPlayerTurn, playerStatus } = usePlayerLegalActions(tableId);
+    const { legalActions, isPlayerTurn, playerStatus } = usePlayerLegalActions();
     const { gameOptions } = useGameOptions(tableId);
     const { dealCards, isDealing } = useTableDeal(tableId);
     const { checkHand } = useTableCheck(tableId);

--- a/ui/src/components/playPage/Players/OppositePlayer.tsx
+++ b/ui/src/components/playPage/Players/OppositePlayer.tsx
@@ -67,7 +67,7 @@ const OppositePlayer: React.FC<OppositePlayerProps> = ({ left, top, index, color
     const { id } = useParams<{ id: string }>();
     const { playerData, stackValue, isFolded, isAllIn, holeCards, round } = usePlayerData(id, index);
     const { winnerInfo } = useWinnerInfo(id);
-    const { showingPlayers } = useShowingCardsByAddress(id);
+    const { showingPlayers } = useShowingCardsByAddress();
 
     // 1) detect when any winner exists
     const hasWinner = React.useMemo(() => Array.isArray(winnerInfo) && winnerInfo.length > 0, [winnerInfo]);

--- a/ui/src/components/playPage/Table.tsx
+++ b/ui/src/components/playPage/Table.tsx
@@ -231,14 +231,12 @@ const Table = () => {
         timeRemaining
     } = useNextToActInfo(id);
 
-    // Add the useShowingCardsByAddress hook
-    const { showingPlayers, isShowdown, refresh: refreshShowingCards } = useShowingCardsByAddress(id);
 
     // Add the useTableLeave hook
     const { leaveTable, isLeaving } = useTableLeave(id);
 
     // Add the useTableState hook to get table state properties
-    const { currentRound, formattedTotalPot, tableSize } = useTableState(id, 5000);
+    const { formattedTotalPot, tableSize } = useTableState(id, 5000);
 
     // Add the useDealerPosition hook
     const { dealerButtonPosition, isDealerButtonVisible } = useDealerPosition(id);
@@ -336,13 +334,6 @@ const Table = () => {
 
     // Winner animations
     const hasWinner = Array.isArray(winnerInfo) && winnerInfo.length > 0;
-
-    // Add useEffect to refresh showing cards when the round is showdown or end
-    useEffect(() => {
-        if (currentRound === "showdown" || currentRound === "end") {
-            refreshShowingCards();
-        }
-    }, [currentRound, refreshShowingCards]);
 
     // Restore the useEffect for the timer
     useEffect(() => {

--- a/ui/src/components/playPage/Table.tsx
+++ b/ui/src/components/playPage/Table.tsx
@@ -217,7 +217,7 @@ const Table = () => {
     const [debugMode, setDebugMode] = useState(false);
 
     // Use the hook directly instead of getting it from context
-    const { legalActions: playerLegalActions } = usePlayerLegalActions(id);
+    const { legalActions: playerLegalActions } = usePlayerLegalActions();
 
     // Add the usePlayerSeatInfo hook
     const { currentUserSeat, getUserBySeat } = usePlayerSeatInfo(id);

--- a/ui/src/hooks/playerActions/types.ts
+++ b/ui/src/hooks/playerActions/types.ts
@@ -1,6 +1,7 @@
 import { LegalActionDTO, PlayerStatus } from "@bitcoinbrisbane/block52";
+import { BaseHookReturn } from "../../types/index";
 
-export interface PlayerLegalActionsResult {
+export interface PlayerLegalActionsResult extends BaseHookReturn {
     legalActions: LegalActionDTO[];
     isSmallBlindPosition: boolean;
     isBigBlindPosition: boolean;
@@ -8,9 +9,6 @@ export interface PlayerLegalActionsResult {
     isPlayerTurn: boolean;
     playerStatus: PlayerStatus | null;
     playerSeat: number | null;
-    isLoading: boolean;
-    error: any;
-    refresh: () => void;
     foldActionIndex: number | null;
     actionTurnIndex: number;
     isPlayerInGame: boolean;

--- a/ui/src/hooks/playerActions/usePlayerLegalActions.ts
+++ b/ui/src/hooks/playerActions/usePlayerLegalActions.ts
@@ -4,14 +4,18 @@ import { LegalActionDTO, PlayerActionType, PlayerDTO } from "@bitcoinbrisbane/bl
 
 /**
  * Custom hook to fetch the legal actions for the current player
- * @param tableId The ID of the table to fetch state for (required - Context manages subscription)
+ * 
+ * NOTE: Table identification and player legal actions are handled through GameStateContext subscription.
+ * Components call subscribeToTable(tableId) which creates a WebSocket connection with both tableAddress 
+ * and playerId (player address) parameters. This hook reads the real-time legal actions from that context.
+ * 
  * @returns Object containing the player's legal actions and related information
  */
-export function usePlayerLegalActions(tableId: string): PlayerLegalActionsResult {
+export function usePlayerLegalActions(): PlayerLegalActionsResult {
     // Get the user's address from localStorage
     const userAddress = localStorage.getItem("user_eth_public_key")?.toLowerCase();
 
-    // Get game state directly from Context - no additional WebSocket connections
+    // Get game state directly from Context - table ID managed by subscription
     const { gameState, isLoading, error } = useGameStateContext();
 
     // Default return value for error/loading states

--- a/ui/src/hooks/playerActions/usePlayerLegalActions.ts
+++ b/ui/src/hooks/playerActions/usePlayerLegalActions.ts
@@ -1,6 +1,6 @@
 import { useGameStateContext } from "../../context/GameStateContext";
 import { PlayerLegalActionsResult } from "./types";
-import { LegalActionDTO, PlayerActionType, PlayerDTO, TexasHoldemStateDTO } from "@bitcoinbrisbane/block52";
+import { LegalActionDTO, PlayerActionType, PlayerDTO } from "@bitcoinbrisbane/block52";
 
 /**
  * Custom hook to fetch the legal actions for the current player

--- a/ui/src/hooks/playerActions/usePlayerLegalActions.ts
+++ b/ui/src/hooks/playerActions/usePlayerLegalActions.ts
@@ -1,44 +1,18 @@
 import { useGameStateContext } from "../../context/GameStateContext";
-import { useState, useCallback } from "react";
-import useSWR from "swr";
 import { PlayerLegalActionsResult } from "./types";
-import { LegalActionDTO, PlayerActionType } from "@bitcoinbrisbane/block52";
+import { LegalActionDTO, PlayerActionType, PlayerDTO, TexasHoldemStateDTO } from "@bitcoinbrisbane/block52";
 
 /**
  * Custom hook to fetch the legal actions for the current player
- * @param tableId The table ID (not used - Context manages subscription)
+ * @param tableId The ID of the table to fetch state for (required - Context manages subscription)
  * @returns Object containing the player's legal actions and related information
  */
-export function usePlayerLegalActions(tableId?: string): PlayerLegalActionsResult {
+export function usePlayerLegalActions(tableId: string): PlayerLegalActionsResult {
     // Get the user's address from localStorage
     const userAddress = localStorage.getItem("user_eth_public_key")?.toLowerCase();
 
-    // State for frequent refreshes
-    const [lastRefresh, setLastRefresh] = useState(0);
-
     // Get game state directly from Context - no additional WebSocket connections
     const { gameState, isLoading, error } = useGameStateContext();
-
-    // Manual refresh function (no-op since WebSocket provides real-time data)
-    const refresh = useCallback(async () => {
-        console.log("Refresh called - WebSocket provides real-time data, no manual refresh needed");
-        return gameState;
-    }, [gameState]);
-
-    // Custom more frequent refresh for this critical hook
-    useSWR(
-        tableId ? `legal-actions-${tableId}` : null,
-        async () => {
-            const now = Date.now();
-            // Refresh if more than 5 seconds have elapsed
-            if (now - lastRefresh >= 5000) {
-                await refresh();
-                setLastRefresh(now);
-            }
-            return null;
-        },
-        { refreshInterval: 5000, revalidateOnFocus: true }
-    );
 
     // Default return value for error/loading states
     const defaultReturn: PlayerLegalActionsResult = {
@@ -51,7 +25,6 @@ export function usePlayerLegalActions(tableId?: string): PlayerLegalActionsResul
         playerSeat: null,
         isLoading,
         error,
-        refresh,
         foldActionIndex: null,
         actionTurnIndex: 0,
         isPlayerInGame: false
@@ -73,16 +46,16 @@ export function usePlayerLegalActions(tableId?: string): PlayerLegalActionsResul
     try {
 
         // Try to find the current player in the table data
-        let currentPlayer = null;
+        let currentPlayer: PlayerDTO | null = null;
         let isPlayerInGame = false;
 
         if (userAddress && gameState.players?.length > 0) {
             // Try to find player with exact address match
-            currentPlayer = gameState.players?.find((player: any) => player.address?.toLowerCase() === userAddress);
+            currentPlayer = gameState.players?.find((player: PlayerDTO) => player.address?.toLowerCase() === userAddress) ?? null;
 
             // If not found, try with case-insensitive comparison
             if (!currentPlayer) {
-                currentPlayer = gameState.players?.find((player: any) => player.address?.toLowerCase().includes(userAddress.substring(0, 10).toLowerCase()));
+                currentPlayer = gameState.players?.find((player: PlayerDTO) => player.address?.toLowerCase().includes(userAddress.substring(0, 10).toLowerCase())) ?? null;
             }
 
             isPlayerInGame = currentPlayer === undefined || currentPlayer === null;
@@ -117,10 +90,10 @@ export function usePlayerLegalActions(tableId?: string): PlayerLegalActionsResul
         }
 
         // Check if it's the player's turn
-        const isPlayerTurn = gameState.nextToAct === currentPlayer.seat;
+        const isPlayerTurn: boolean = gameState.nextToAct === currentPlayer.seat;
 
         // Find the fold action index
-        let foldActionIndex = null;
+        let foldActionIndex: number | null = null;
         if (Array.isArray(currentPlayer.legalActions)) {
             const foldAction = currentPlayer.legalActions.find((action: LegalActionDTO) => action.action === PlayerActionType.FOLD);
             if (foldAction) {
@@ -130,7 +103,7 @@ export function usePlayerLegalActions(tableId?: string): PlayerLegalActionsResul
 
         // Calculate the common action turn index
         // Get all indices from all legal actions
-        let actionTurnIndex = 0;
+        let actionTurnIndex: number = 0;
         if (Array.isArray(currentPlayer.legalActions) && currentPlayer.legalActions.length > 0) {
             // Get the first index - all actions should have the same index
             const firstActionIndex = currentPlayer.legalActions[0].index;
@@ -150,8 +123,7 @@ export function usePlayerLegalActions(tableId?: string): PlayerLegalActionsResul
         }
 
         // Extract and return all the relevant information
-        // TODO: MAKE A STRONG TYPE
-        const result = {
+        const result: PlayerLegalActionsResult = {
             legalActions: Array.isArray(currentPlayer.legalActions) ? currentPlayer.legalActions : [],
             isSmallBlindPosition: currentPlayer.isSmallBlind || gameState.smallBlindPosition === currentPlayer.seat,
             isBigBlindPosition: currentPlayer.isBigBlind || gameState.bigBlindPosition === currentPlayer.seat,
@@ -161,7 +133,6 @@ export function usePlayerLegalActions(tableId?: string): PlayerLegalActionsResul
             playerSeat: currentPlayer.seat || null,
             isLoading: false,
             error: null,
-            refresh,
             foldActionIndex,
             actionTurnIndex, // Add the common action turn index
             isPlayerInGame // Add the flag indicating if the player is in the game
@@ -172,7 +143,7 @@ export function usePlayerLegalActions(tableId?: string): PlayerLegalActionsResul
         console.error("⚠️ Error parsing player legal actions:", err);
         return {
             ...defaultReturn,
-            error: err
+            error: err instanceof Error ? err : new Error("Unknown error occurred")
         };
     }
 }

--- a/ui/src/hooks/useShowingCardsByAddress.ts
+++ b/ui/src/hooks/useShowingCardsByAddress.ts
@@ -1,22 +1,20 @@
-import { useMemo, useCallback } from "react";
+import { useMemo} from "react";
 import { useGameStateContext } from "../context/GameStateContext";
 import { PlayerDTO, PlayerStatus, TexasHoldemRound } from "@bitcoinbrisbane/block52";
 import { ShowingCardsByAddressReturn, ShowingCardData } from "../types/index";
 
 /**
  * Custom hook to get hole cards of players who have shown their cards
- * @param tableId The ID of the table (not used - Context manages subscription)
+ * 
+ * NOTE: Player showing status and hole cards are handled through GameStateContext subscription.
+ * Components call subscribeToTable(tableId) which creates a WebSocket connection with both tableAddress 
+ * and playerId parameters. This hook reads the real-time showing cards data from that context.
+ * 
  * @returns Object containing all players with "showing" status and their cards
  */
-export const useShowingCardsByAddress = (tableId?: string): ShowingCardsByAddressReturn => {
-  // Get game state directly from Context - no additional WebSocket connections
+export const useShowingCardsByAddress = (): ShowingCardsByAddressReturn => {
+  // Get game state directly from Context - real-time data via WebSocket
   const { gameState, isLoading, error } = useGameStateContext();
-  
-  // Manual refresh function (no-op since WebSocket provides real-time data)
-  const refresh = useCallback(async () => {
-    console.log("Refresh called - WebSocket provides real-time data, no manual refresh needed");
-    return gameState;
-  }, [gameState]);
   
   // Check if round is showdown or end
   const isShowdown = useMemo((): boolean => {
@@ -50,7 +48,6 @@ export const useShowingCardsByAddress = (tableId?: string): ShowingCardsByAddres
     showingPlayers,
     isShowdown,
     isLoading,
-    error,
-    refresh
+    error
   };
 }; 

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -271,7 +271,6 @@ export interface ShowingCardData {
 export interface ShowingCardsByAddressReturn extends BaseHookReturn {
     showingPlayers: ShowingCardData[];
     isShowdown: boolean;
-    refresh: () => Promise<TexasHoldemStateDTO | undefined>;
 }
 
 // Type for the return value of useTableAnimations hook


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the retrieval of player actions and showing cards by removing manual refresh logic and unnecessary parameters.
  - Improved real-time updates by relying fully on live game state subscriptions, eliminating the need for manual data refreshes in the UI.
  - Streamlined several components by removing unused logic related to showing cards and refresh triggers.
- **Style**
  - Enhanced type safety and error handling for more robust user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->