### PR TITLE
fix: update NewTableCommand to handle nonce and schemaAddress correctly

### DIFF
--- a/pvm/ts/src/commands/newTableCommand.ts
+++ b/pvm/ts/src/commands/newTableCommand.ts
@@ -7,7 +7,12 @@ export class NewTableCommand implements ISignedCommand<string> {
     private readonly gameManagement: IGameManagement;
     private readonly contractSchemas: IContractSchemaManagement;
 
-    constructor(private readonly owner: string, private readonly schemaAddress: string, private readonly privateKey: string) {
+    constructor(
+        private readonly owner: string, 
+        private readonly schemaAddress: string, 
+        private readonly nonce: bigint,
+        private readonly privateKey: string
+    ) {
         this.gameManagement = getGameManagementInstance();
         this.contractSchemas = getContractSchemaManagementInstance();
     }
@@ -19,7 +24,7 @@ export class NewTableCommand implements ISignedCommand<string> {
             throw new Error(`Game options not found for schema address: ${this.schemaAddress}`);
         }
 
-        const address = await this.gameManagement.create(0n, this.schemaAddress, gameOptions);
+        const address = await this.gameManagement.create(this.nonce, this.schemaAddress, gameOptions);
 
         return signResult(address, this.privateKey);
     }

--- a/pvm/ts/src/rpc.ts
+++ b/pvm/ts/src/rpc.ts
@@ -354,8 +354,9 @@ export class RPC {
                 }
 
                 case RPCMethods.NEW_TABLE: {
-                    const [to, owner] = request.params as RPCRequestParams[RPCMethods.NEW_TABLE];
-                    const command = new NewTableCommand(to, owner, validatorPrivateKey);
+                    // The SDK sends [schemaAddress, owner, nonce] but the type only expects 2 params
+                    const [schemaAddress, owner, nonce] = request.params as [string, string, number];
+                    const command = new NewTableCommand(owner, schemaAddress, BigInt(nonce || 0), validatorPrivateKey);
                     result = await command.execute();
                     break;
                 }

--- a/sdk/src/types/rpc.ts
+++ b/sdk/src/types/rpc.ts
@@ -80,7 +80,7 @@ export type RPCRequestParams = {
     [RPCMethods.MINED_BLOCK_HASH]: [string, string]; // [blockHash, nodeUrl]
     [RPCMethods.MINT]: [string]; // [depositIndex]
     [RPCMethods.NEW_HAND]: [string, string, number, string]; // [to, nonce, index, data] where data is the seed
-    [RPCMethods.NEW_TABLE]: [string, string]; // [from (creator), to (schema)]
+    [RPCMethods.NEW_TABLE]: [string, string, number]; // [schemaAddress, owner, nonce]
     [RPCMethods.PERFORM_ACTION]: [string, string, string, string | null, string, number, string]; // [from, to, action, amount, nonce, index, data]
     [RPCMethods.PURGE]: [string, string]; // [username, password]
     [RPCMethods.RESET_BLOCKCHAIN]: [string, string]; // [username, password]


### PR DESCRIPTION
- Modified the constructor of NewTableCommand to accept a nonce parameter as bigint.
- Updated the execution logic to use the nonce when creating a new table, ensuring proper handling of game state and schema address as per the sdk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for specifying a custom nonce when creating a new table via the relevant command and RPC method.

- **Bug Fixes**
  - Improved parameter handling for the "create new table" action to align with expected input structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->