### PR TITLE
fix: correct winner card assignment in TexasHoldemGame to use the cur…

### DIFF
--- a/pvm/ts/src/engine/texasHoldem.ts
+++ b/pvm/ts/src/engine/texasHoldem.ts
@@ -1179,7 +1179,7 @@ class TexasHoldemGame implements IPoker, IUpdate {
                 const hand = hands.get(player.id);
                 const _winner: Winner = {
                     amount: this.getPot(),
-                    cards: activePlayers[0].holeCards?.map(card => card.mnemonic),
+                    cards: player.holeCards?.map(card => card.mnemonic),
                     name: hand.name,
                     description: hand.descr
                 };


### PR DESCRIPTION
…rent player's hole cards by using the correct array.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected the display of winning players' hole cards in the event of a tie, ensuring each winner's cards are shown accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->