### PR TITLE
Split pot when multiple winners

### DIFF
--- a/pvm/ts/src/engine/texasHoldem.ts
+++ b/pvm/ts/src/engine/texasHoldem.ts
@@ -1177,14 +1177,15 @@ class TexasHoldemGame implements IPoker, IUpdate {
         for (const player of showingPlayers) {
             if (winningHands.includes(hands.get(player.id))) {
                 const hand = hands.get(player.id);
+                const winAmount = pot / winnersCount;
                 const _winner: Winner = {
-                    amount: this.getPot(),
+                    amount: winAmount,
                     cards: player.holeCards?.map(card => card.mnemonic),
                     name: hand.name,
                     description: hand.descr
                 };
 
-                const winAmount = pot / winnersCount;
+                // const winAmount = pot / winnersCount;
                 player.chips += winAmount;
                 this._winners.set(player.address, _winner);
             }

--- a/pvm/ts/src/engine/texasHoldem.ts
+++ b/pvm/ts/src/engine/texasHoldem.ts
@@ -1179,7 +1179,7 @@ class TexasHoldemGame implements IPoker, IUpdate {
                 const hand = hands.get(player.id);
                 const _winner: Winner = {
                     amount: this.getPot(),
-                    cards: activePlayers[0].holeCards?.map(card => card.mnemonic),
+                    cards: player.holeCards?.map(card => card.mnemonic),
                     name: hand.name,
                     description: hand.descr
                 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected pot distribution among multiple winners in Texas Hold'em so that winnings are split evenly.
  - Ensured each winner's displayed cards reflect their own hole cards, not another player's.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->