### PR TITLE
899 call value after a raise on pre flop

### DIFF
--- a/pvm/ts/src/engine/actions/baseAction.ts
+++ b/pvm/ts/src/engine/actions/baseAction.ts
@@ -1,4 +1,4 @@
-import { NonPlayerActionType, PlayerActionType, PlayerStatus } from "@bitcoinbrisbane/block52";
+import { NonPlayerActionType, PlayerActionType, PlayerStatus, TexasHoldemRound } from "@bitcoinbrisbane/block52";
 import { Player } from "../../models/player";
 import TexasHoldemGame from "../texasHoldem";
 import { IUpdate, Range } from "../types";
@@ -54,26 +54,64 @@ abstract class BaseAction {
     }
 
     // Get the largest bet in the current round
-    protected getLargestBet(): bigint {
-        let amount = 0n;
+    protected getLargestBet(includeBlinds: boolean = false): bigint {
+        let largestBettor: string = "";
+        let _amount = 0n;
         const roundBets = this.game.getBets(this.game.currentRound);
 
-        roundBets.forEach(bet => {
-            if (bet > amount) {
-                amount = bet;
-            }
-        });
+        // roundBets.forEach(bet => {
+        //     if (bet > amount) {
+        //         amount = bet;
+        //     }
+        // });
 
-        return amount;
+        for (const [playerId, amount] of roundBets.entries()) {
+            console.log(`Player: ${playerId}, Bet: ${amount}`);
+            // playerId is the key, amount is the value
+            if (amount > _amount) {
+                _amount = amount;
+                largestBettor = playerId;
+            }
+        }
+
+        if (includeBlinds && this.game.currentRound === TexasHoldemRound.PREFLOP) {
+
+            const smallBlindPosition = this.game.smallBlindPosition;
+            const smallBlindPlayer = this.game.getPlayerAtSeat(smallBlindPosition);
+
+            // if the bet map is the small blind, we need to add the small blind amount
+            if (largestBettor === smallBlindPlayer?.address) {
+                _amount += this.game.smallBlind;
+            }
+
+            const bigBlindPosition = this.game.bigBlindPosition;
+            const bigBlindPlayer = this.game.getPlayerAtSeat(bigBlindPosition);
+
+            // if the bet map is the big blind, we need to add the big blind amount
+            if (largestBettor === bigBlindPlayer?.address) {
+                _amount += this.game.bigBlind;
+            }
+        }
+
+        return _amount;
     }
 
-    protected getSumBets(playerId: string): bigint {
+    protected getSumBets(playerId: string, includeBlinds: boolean = false): bigint {
         let amount = 0n;
         const roundBets = this.game.getBets(this.game.currentRound);
 
         // If the player made a bet in this round, add it to the total
         if (roundBets.has(playerId)) {
             amount += roundBets.get(playerId) || 0n;
+        }
+
+        if (includeBlinds && this.game.currentRound === TexasHoldemRound.PREFLOP) {
+            const anteBets = this.game.getBets(TexasHoldemRound.ANTE);
+
+            // If the player made an ante bet, add it to the total
+            if (anteBets.has(playerId)) {
+                amount += anteBets.get(playerId) || 0n;
+            }
         }
 
         return amount;

--- a/pvm/ts/src/engine/actions/callAction.ts
+++ b/pvm/ts/src/engine/actions/callAction.ts
@@ -23,13 +23,13 @@ class CallAction extends BaseAction implements IAction {
             const seat = this.game.getPlayerSeatNumber(player.address);
             if (seat === this.game.smallBlindPosition) {
                 // Small blind needs to call the difference to match big blind
-                const largestBet = this.getLargestBet();
-                const amount = (largestBet + this.game.bigBlind) - this.game.smallBlind;
-                return { minAmount: amount, maxAmount: amount };
+                const largestBet = this.getLargestBet(true);
+                // const amount = (largestBet + this.game.bigBlind) - this.game.smallBlind;
+                return { minAmount: largestBet, maxAmount: largestBet };
             }
 
-            const largestBet = this.getLargestBet();
-            const playerBet = this.getSumBets(player.address);
+            const largestBet = this.getLargestBet(true);
+            const playerBet = this.getSumBets(player.address, true);
             
             if (seat === this.game.bigBlindPosition && largestBet === playerBet) {
                 // Error message not quite right
@@ -107,14 +107,6 @@ class CallAction extends BaseAction implements IAction {
             // Small blind calling the big blind (difference between BB and SB)
             return this.game.bigBlind - this.game.smallBlind;
         }
-
-        // if (this.game.currentRound === TexasHoldemRound.PREFLOP && playerSeat === this.game.smallBlindPosition) {
-        //     playerBet += this.game.smallBlind; // Assume small blind has already put in their small blind amount
-        // }
-
-        // if (this.game.currentRound === TexasHoldemRound.PREFLOP && playerSeat === this.game.bigBlindPosition) {
-        //     playerBet += this.game.bigBlind; // Assume big blind has already put in their big blind amount
-        // }
 
         // General case: difference between largest bet and player's current bet
         if (playerBet >= largestBet) {

--- a/pvm/ts/src/engine/actions/callAction.ts
+++ b/pvm/ts/src/engine/actions/callAction.ts
@@ -23,7 +23,8 @@ class CallAction extends BaseAction implements IAction {
             const seat = this.game.getPlayerSeatNumber(player.address);
             if (seat === this.game.smallBlindPosition) {
                 // Small blind needs to call the difference to match big blind
-                const amount = this.game.bigBlind - this.game.smallBlind;
+                const largestBet = this.getLargestBet();
+                const amount = (largestBet + this.game.bigBlind) - this.game.smallBlind;
                 return { minAmount: amount, maxAmount: amount };
             }
 

--- a/pvm/ts/src/engine/actions/callAction.ts
+++ b/pvm/ts/src/engine/actions/callAction.ts
@@ -98,7 +98,9 @@ class CallAction extends BaseAction implements IAction {
         // Special case for small blind in preflop
         if (this.game.currentRound === TexasHoldemRound.PREFLOP && playerSeat === this.game.smallBlindPosition && playerBet === this.game.smallBlind) {
             // Small blind calling the big blind (difference between BB and SB)
-            return this.game.bigBlind - this.game.smallBlind;
+            const largestBet = this.getLargestBet();
+            const amount = (largestBet + this.game.bigBlind) - this.game.smallBlind;
+            return amount;
         }
 
         // Special case for small blind in preflop UTG

--- a/pvm/ts/src/engine/actions/callAction.ts
+++ b/pvm/ts/src/engine/actions/callAction.ts
@@ -92,13 +92,12 @@ class CallAction extends BaseAction implements IAction {
 
     getDeductAmount(player: Player): bigint {
         const playerSeat = this.game.getPlayerSeatNumber(player.address);
-        const playerBet = this.getSumBets(player.address);
-        const largestBet = this.getLargestBet();
+        let playerBet = this.getSumBets(player.address, true); // Include ante bets in preflop
+        const largestBet = this.getLargestBet(true);
 
         // Special case for small blind in preflop
         if (this.game.currentRound === TexasHoldemRound.PREFLOP && playerSeat === this.game.smallBlindPosition && playerBet === this.game.smallBlind) {
             // Small blind calling the big blind (difference between BB and SB)
-            const largestBet = this.getLargestBet();
             const amount = (largestBet + this.game.bigBlind) - this.game.smallBlind;
             return amount;
         }
@@ -108,6 +107,14 @@ class CallAction extends BaseAction implements IAction {
             // Small blind calling the big blind (difference between BB and SB)
             return this.game.bigBlind - this.game.smallBlind;
         }
+
+        // if (this.game.currentRound === TexasHoldemRound.PREFLOP && playerSeat === this.game.smallBlindPosition) {
+        //     playerBet += this.game.smallBlind; // Assume small blind has already put in their small blind amount
+        // }
+
+        // if (this.game.currentRound === TexasHoldemRound.PREFLOP && playerSeat === this.game.bigBlindPosition) {
+        //     playerBet += this.game.bigBlind; // Assume big blind has already put in their big blind amount
+        // }
 
         // General case: difference between largest bet and player's current bet
         if (playerBet >= largestBet) {

--- a/pvm/ts/tests/senario.test.ts
+++ b/pvm/ts/tests/senario.test.ts
@@ -1,7 +1,7 @@
 import { TexasHoldemRound } from "@bitcoinbrisbane/block52";
 import TexasHoldemGame from "../src/engine/texasHoldem";
 import { fromTestJson } from "../src/engine/testConstants";
-import { test_json, test_735, test_753, test_792, test_870, test_873, test_873_2, test_877 } from "./senarios/data";
+import { test_json, test_735, test_753, test_792, test_870, test_873, test_873_2, test_877, test_899 } from "./senarios/data";
 
 // This test suite is for the Texas Holdem game engine, specifically for the Ante round in a heads-up scenario.
 describe("Texas Holdem - Data driven", () => {
@@ -100,10 +100,24 @@ describe("Texas Holdem - Data driven", () => {
             expect(game.bigBlindPosition).toEqual(2);
         });
 
-        it.only("should test bug 877", () => {
+        it("should test bug 877", () => {
             game = fromTestJson(test_877);
             // Game state should be end
             expect(game.currentRound).toEqual(TexasHoldemRound.END);
+        });
+
+        it.only("should test bug 899", () => {
+            const SEAT_1 = "0x4260E88e81E60113146092Fb9474b61C59f7552e";
+
+            game = fromTestJson(test_899);
+            // Game state should be end
+            const actual = game.getLegalActions(SEAT_1);
+            expect(actual).toBeDefined();
+            expect(actual.length).toEqual(3);
+            expect(actual[1].action).toEqual("call");
+            expect(actual[1].min).toEqual("30000000000000000");
+            expect(actual[1].max).toEqual("30000000000000000");
+            expect(actual[2].action).toEqual("raise");
         });
     });
 });

--- a/pvm/ts/tests/senario.test.ts
+++ b/pvm/ts/tests/senario.test.ts
@@ -1,7 +1,7 @@
 import { TexasHoldemRound } from "@bitcoinbrisbane/block52";
 import TexasHoldemGame from "../src/engine/texasHoldem";
 import { fromTestJson } from "../src/engine/testConstants";
-import { test_json, test_735, test_753, test_792, test_870, test_873, test_873_2, test_877, test_899 } from "./senarios/data";
+import { test_json, test_735, test_753, test_792, test_870, test_873, test_873_2, test_877, test_899, test_899_2 } from "./senarios/data";
 
 // This test suite is for the Texas Holdem game engine, specifically for the Ante round in a heads-up scenario.
 describe("Texas Holdem - Data driven", () => {
@@ -106,7 +106,7 @@ describe("Texas Holdem - Data driven", () => {
             expect(game.currentRound).toEqual(TexasHoldemRound.END);
         });
 
-        it.only("should test bug 899", () => {
+        it("should test bug 899", () => {
             const SEAT_1 = "0x4260E88e81E60113146092Fb9474b61C59f7552e";
 
             game = fromTestJson(test_899);
@@ -117,6 +117,20 @@ describe("Texas Holdem - Data driven", () => {
             expect(actual[1].action).toEqual("call");
             expect(actual[1].min).toEqual("30000000000000000");
             expect(actual[1].max).toEqual("30000000000000000");
+            expect(actual[2].action).toEqual("raise");
+        });
+
+        it.only("should test bug 899 second test", () => {
+            const SEAT_8 = "0x4260E88e81E60113146092Fb9474b61C59f7552e";
+
+            game = fromTestJson(test_899_2);
+            // Game state should be end
+            const actual = game.getLegalActions(SEAT_8);
+            expect(actual).toBeDefined();
+            expect(actual.length).toEqual(3);
+            expect(actual[1].action).toEqual("call");
+            expect(actual[1].min).toEqual("20000000000000000");
+            expect(actual[1].max).toEqual("20000000000000000");
             expect(actual[2].action).toEqual("raise");
         });
     });

--- a/pvm/ts/tests/senarios/data.ts
+++ b/pvm/ts/tests/senarios/data.ts
@@ -1510,3 +1510,158 @@ export const test_899 = {
         "signature": "0xec7fa05bb6dde4bc38beec515c51c0809fa5c22d2ce46c30cbc71ed0eb174afe0919efc953980fda972cfdada898413bb66a48cb98892d6f4574403807257dee1b"
     }
 }
+
+export const test_899_2 = {
+    "id": "1",
+    "result": {
+        "data": {
+            "type": "cash",
+            "address": "0xb3b36d89cc03e1fb4cc4b83e495205f2d7203b7a",
+            "gameOptions": {
+                "minBuyIn": "10000000000000000",
+                "maxBuyIn": "1000000000000000000",
+                "maxPlayers": 9,
+                "minPlayers": 2,
+                "smallBlind": "10000000000000000",
+                "bigBlind": "20000000000000000",
+                "timeout": 30000
+            },
+            "smallBlindPosition": 1,
+            "bigBlindPosition": 8,
+            "dealer": 9,
+            "players": [
+                {
+                    "address": "0xE8DE79b707BfB7d8217cF0a494370A9cC251602C",
+                    "seat": 1,
+                    "stack": "960000000000000000",
+                    "isSmallBlind": true,
+                    "isBigBlind": false,
+                    "isDealer": false,
+                    "holeCards": [
+                        "3H",
+                        "AC"
+                    ],
+                    "status": "active",
+                    "lastAction": {
+                        "playerId": "0xE8DE79b707BfB7d8217cF0a494370A9cC251602C",
+                        "seat": 1,
+                        "action": "raise",
+                        "amount": "30000000000000000",
+                        "round": "preflop",
+                        "index": 6,
+                        "timestamp": 1749691597636
+                    },
+                    "legalActions": [],
+                    "sumOfBets": "30000000000000000",
+                    "timeout": 0,
+                    "signature": "0x0000000000000000000000000000000000000000000000000000000000000000"
+                },
+                {
+                    "address": "0x4260E88e81E60113146092Fb9474b61C59f7552e",
+                    "seat": 8,
+                    "stack": "980000000000000000",
+                    "isSmallBlind": false,
+                    "isBigBlind": true,
+                    "isDealer": false,
+                    "holeCards": [
+                        "7H",
+                        "9D"
+                    ],
+                    "status": "active",
+                    "legalActions": [
+                        {
+                            "action": "fold",
+                            "min": "0",
+                            "max": "0",
+                            "index": 7
+                        },
+                        {
+                            "action": "call",
+                            "min": "30000000000000000",
+                            "max": "30000000000000000",
+                            "index": 7
+                        },
+                        {
+                            "action": "raise",
+                            "min": "30000000000000000",
+                            "max": "980000000000000000",
+                            "index": 7
+                        }
+                    ],
+                    "sumOfBets": "0",
+                    "timeout": 0,
+                    "signature": "0x0000000000000000000000000000000000000000000000000000000000000000"
+                }
+            ],
+            "communityCards": [],
+            "deck": "3H-7H-AC-9D-[KC]-6S-10H-9C-QD-JH-KH-10C-4D-2H-5D-8H-KS-4S-6D-QH-10S-3S-JS-3D-6H-AH-2C-5H-2S-10D-QC-9H-7S-KD-6C-8S-5S-5C-7C-8D-AD-JC-8C-4H-3C-2D-QS-7D-4C-AS-JD-9S",
+            "pots": [
+                "60000000000000000"
+            ],
+            "lastActedSeat": 1,
+            "actionCount": 0,
+            "handNumber": 1,
+            "nextToAct": 8,
+            "previousActions": [
+                {
+                    "playerId": "0xE8DE79b707BfB7d8217cF0a494370A9cC251602C",
+                    "seat": 1,
+                    "action": "join",
+                    "amount": "1000000000000000000",
+                    "round": "ante",
+                    "index": 1,
+                    "timestamp": 1749691597636
+                },
+                {
+                    "playerId": "0x4260E88e81E60113146092Fb9474b61C59f7552e",
+                    "seat": 8,
+                    "action": "join",
+                    "amount": "1000000000000000000",
+                    "round": "ante",
+                    "index": 2,
+                    "timestamp": 1749691597636
+                },
+                {
+                    "playerId": "0xE8DE79b707BfB7d8217cF0a494370A9cC251602C",
+                    "seat": 1,
+                    "action": "post-small-blind",
+                    "amount": "10000000000000000",
+                    "round": "ante",
+                    "index": 3,
+                    "timestamp": 1749691597636
+                },
+                {
+                    "playerId": "0x4260E88e81E60113146092Fb9474b61C59f7552e",
+                    "seat": 8,
+                    "action": "post-big-blind",
+                    "amount": "20000000000000000",
+                    "round": "ante",
+                    "index": 4,
+                    "timestamp": 1749691597636
+                },
+                {
+                    "playerId": "0xE8DE79b707BfB7d8217cF0a494370A9cC251602C",
+                    "seat": 1,
+                    "action": "deal",
+                    "amount": "",
+                    "round": "ante",
+                    "index": 5,
+                    "timestamp": 1749691597636
+                },
+                {
+                    "playerId": "0xE8DE79b707BfB7d8217cF0a494370A9cC251602C",
+                    "seat": 1,
+                    "action": "raise",
+                    "amount": "30000000000000000",
+                    "round": "preflop",
+                    "index": 6,
+                    "timestamp": 1749691597636
+                }
+            ],
+            "round": "preflop",
+            "winners": [],
+            "signature": "0x0000000000000000000000000000000000000000000000000000000000000000"
+        },
+        "signature": "0x52e4dce70fb8ae5c80cfbb77081602a97e88999ade046fa289d6418176ef9603718c5a90fcc5410b27ec78577c8ecc4d25c7d840e812d955e6725a754292417e1c"
+    }
+}

--- a/pvm/ts/tests/senarios/data.ts
+++ b/pvm/ts/tests/senarios/data.ts
@@ -1324,3 +1324,189 @@ export const test_877 = {
         "signature": "0x3ba0a4b155e82bd4989c753ae7611543d82cbad555227c5e6e0820b004bfe3c024670b42cc1021ce5d456cfef20e0fab1e3342b1a1c0eea2928d194790317ee41b"
     }
 }
+
+export const test_899 = {
+    "id": "1",
+    "result": {
+        "data": {
+            "type": "cash",
+            "address": "0x89dc1fa1f9a1efba25bb6f6b1444064d42071385",
+            "gameOptions": {
+                "minBuyIn": "10000000000000000",
+                "maxBuyIn": "1000000000000000000",
+                "maxPlayers": 9,
+                "minPlayers": 2,
+                "smallBlind": "10000000000000000",
+                "bigBlind": "20000000000000000",
+                "timeout": 30000
+            },
+            "smallBlindPosition": 1,
+            "bigBlindPosition": 2,
+            "dealer": 9,
+            "players": [
+                {
+                    "address": "0x4260E88e81E60113146092Fb9474b61C59f7552e",
+                    "seat": 1,
+                    "stack": "990000000000000000",
+                    "isSmallBlind": true,
+                    "isBigBlind": false,
+                    "isDealer": false,
+                    "holeCards": [
+                        "2H",
+                        "3H"
+                    ],
+                    "status": "active",
+                    "legalActions": [
+                        {
+                            "action": "fold",
+                            "min": "0",
+                            "max": "0",
+                            "index": 8
+                        },
+                        {
+                            "action": "call",
+                            "min": "10000000000000000",
+                            "max": "10000000000000000",
+                            "index": 8
+                        },
+                        {
+                            "action": "raise",
+                            "min": "30000000000000000",
+                            "max": "990000000000000000",
+                            "index": 8
+                        }
+                    ],
+                    "sumOfBets": "0",
+                    "timeout": 0,
+                    "signature": "0x0000000000000000000000000000000000000000000000000000000000000000"
+                },
+                {
+                    "address": "0xE8DE79b707BfB7d8217cF0a494370A9cC251602C",
+                    "seat": 6,
+                    "stack": "960000000000000000",
+                    "isSmallBlind": false,
+                    "isBigBlind": false,
+                    "isDealer": false,
+                    "holeCards": [
+                        "2H",
+                        "3H"
+                    ],
+                    "status": "active",
+                    "lastAction": {
+                        "playerId": "0xE8DE79b707BfB7d8217cF0a494370A9cC251602C",
+                        "seat": 6,
+                        "action": "bet",
+                        "amount": "20000000000000000",
+                        "round": "preflop",
+                        "index": 7,
+                        "timestamp": 1749687513167
+                    },
+                    "legalActions": [],
+                    "sumOfBets": "20000000000000000",
+                    "timeout": 0,
+                    "signature": "0x0000000000000000000000000000000000000000000000000000000000000000"
+                },
+                {
+                    "address": "0xC84737526E425D7549eF20998Fa992f88EAC2484",
+                    "seat": 2,
+                    "stack": "1000000000000000000",
+                    "isSmallBlind": false,
+                    "isBigBlind": true,
+                    "isDealer": false,
+                    "status": "active",
+                    "lastAction": {
+                        "playerId": "0xC84737526E425D7549eF20998Fa992f88EAC2484",
+                        "seat": 2,
+                        "action": "join",
+                        "amount": "1000000000000000000",
+                        "round": "preflop",
+                        "index": 6,
+                        "timestamp": 1749687513167
+                    },
+                    "legalActions": [],
+                    "sumOfBets": "0",
+                    "timeout": 0,
+                    "signature": "0x0000000000000000000000000000000000000000000000000000000000000000"
+                }
+            ],
+            "communityCards": [],
+            "deck": "2H-10C-JH-4H-[JD]-8S-7S-9D-2D-3H-KC-QH-4C-4S-5H-AC-10D-4D-3D-6C-9C-2S-6D-QD-5S-8C-8D-KD-9S-6H-AH-9H-7C-KS-10S-5C-7D-QC-JS-3S-AD-8H-6S-7H-AS-JC-KH-2C-10H-QS-5D-3C",
+            "pots": [
+                "50000000000000000"
+            ],
+            "lastActedSeat": 6,
+            "actionCount": 0,
+            "handNumber": 1,
+            "nextToAct": 1,
+            "previousActions": [
+                {
+                    "playerId": "0x4260E88e81E60113146092Fb9474b61C59f7552e",
+                    "seat": 1,
+                    "action": "join",
+                    "amount": "1000000000000000000",
+                    "round": "ante",
+                    "index": 1,
+                    "timestamp": 1749687513167
+                },
+                {
+                    "playerId": "0xE8DE79b707BfB7d8217cF0a494370A9cC251602C",
+                    "seat": 6,
+                    "action": "join",
+                    "amount": "1000000000000000000",
+                    "round": "ante",
+                    "index": 2,
+                    "timestamp": 1749687513167
+                },
+                {
+                    "playerId": "0x4260E88e81E60113146092Fb9474b61C59f7552e",
+                    "seat": 1,
+                    "action": "post-small-blind",
+                    "amount": "10000000000000000",
+                    "round": "ante",
+                    "index": 3,
+                    "timestamp": 1749687513167
+                },
+                {
+                    "playerId": "0xE8DE79b707BfB7d8217cF0a494370A9cC251602C",
+                    "seat": 6,
+                    "action": "post-big-blind",
+                    "amount": "20000000000000000",
+                    "round": "ante",
+                    "index": 4,
+                    "timestamp": 1749687513167
+                },
+                {
+                    "playerId": "0x4260E88e81E60113146092Fb9474b61C59f7552e",
+                    "seat": 1,
+                    "action": "deal",
+                    "amount": "",
+                    "round": "ante",
+                    "index": 5,
+                    "timestamp": 1749687513167
+                },
+                {
+                    "playerId": "0xC84737526E425D7549eF20998Fa992f88EAC2484",
+                    "seat": 2,
+                    "action": "join",
+                    "amount": "1000000000000000000",
+                    "round": "preflop",
+                    "index": 6,
+                    "timestamp": 1749687513167
+                },
+                {
+                    "playerId": "0xE8DE79b707BfB7d8217cF0a494370A9cC251602C",
+                    "seat": 6,
+                    "action": "bet",
+                    "amount": "20000000000000000",
+                    "round": "preflop",
+                    "index": 7,
+                    "timestamp": 1749687513167
+                }
+            ],
+            "round": "preflop",
+            "winners": [],
+            "signature": "0x0000000000000000000000000000000000000000000000000000000000000000"
+        },
+        "signature": "0xec7fa05bb6dde4bc38beec515c51c0809fa5c22d2ce46c30cbc71ed0eb174afe0919efc953980fda972cfdada898413bb66a48cb98892d6f4574403807257dee1b"
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved calculation of call and bet amounts in preflop rounds, especially for small blind and big blind positions, ensuring more accurate gameplay.
- **Tests**
	- Added new test scenarios to verify correct handling of specific betting edge cases in Texas Holdem.
- **Chores**
	- Enhanced test data with additional poker game states for more comprehensive coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->