### PR TITLE
Fix Opposite Player size to equal Player component size

### DIFF
--- a/ui/src/components/playPage/Players/OppositePlayer.tsx
+++ b/ui/src/components/playPage/Players/OppositePlayer.tsx
@@ -115,7 +115,7 @@ const OppositePlayer: React.FC<OppositePlayerProps> = React.memo(({ left, top, i
             {/* Main player display */}
             <div
                 key={index}
-                className={`${opacityClass} absolute flex flex-col justify-center text-gray-600 w-[150px] h-[140px] mt-[40px] transform -translate-x-1/2 -translate-y-1/2 cursor-pointer z-[20]`}
+                className={`${opacityClass} absolute flex flex-col justify-center text-gray-600 w-[160px] h-[140px] mt-[40px] transform -translate-x-1/2 -translate-y-1/2 cursor-pointer z-[20]`}
                 style={{
                     left: left,
                     top: top,
@@ -131,14 +131,14 @@ const OppositePlayer: React.FC<OppositePlayerProps> = React.memo(({ left, top, i
                         isShowingCards && showingCards ? (
                             // Show the actual cards if player is showing
                             <>
-                                <img src={`/cards/${showingCards[0]}.svg`} alt="Player Card 1" className="w-[35%] h-[auto]" />
-                                <img src={`/cards/${showingCards[1]}.svg`} alt="Player Card 2" className="w-[35%] h-[auto]" />
+                                <img src={`/cards/${showingCards[0]}.svg`} alt="Player Card 1" width={60} height={80} className="mb-[11px]" />
+                                <img src={`/cards/${showingCards[1]}.svg`} alt="Player Card 2" width={60} height={80} className="mb-[11px]" />
                             </>
                         ) : (
                             // Show card backs if not showing
                             <>
-                                <img src="/cards/BackCustom.svg" alt="Opposite Player Card" className="w-[35%] h-[auto]" />
-                                <img src="/cards/BackCustom.svg" alt="Opposite Player Card" className="w-[35%] h-[auto]" />
+                                <img src="/cards/BackCustom.svg" alt="Opposite Player Card" width={60} height={80} className="mb-[11px]"  />
+                                <img src="/cards/BackCustom.svg" alt="Opposite Player Card" width={60} height={80} className="mb-[11px]"  />
                             </>
                         )
                     ) : (


### PR DESCRIPTION
Fix Opposite player components (cards, profile, etc) to now equal player size
<img width="1800" height="1145" alt="Screenshot 2025-07-15 at 3 13 59 pm" src="https://github.com/user-attachments/assets/c710eaf9-e0b1-4943-b3d2-2dbcd9414bc8" />
<img width="2560" height="1440" alt="Screenshot 2025-07-15 at 3 16 19 pm" src="https://github.com/user-attachments/assets/92325f75-c297-4396-b394-9f07558b5e1a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the player display area to be wider.
  * Standardized card image sizes for more consistent appearance.
  * Improved spacing below card images for better visual alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->