### PR TITLE
fix: comment out player timeout handling logic in Texas Holdem game

### DIFF
--- a/pvm/ts/src/engine/texasHoldem.ts
+++ b/pvm/ts/src/engine/texasHoldem.ts
@@ -53,6 +53,7 @@ class TexasHoldemGame implements IDealerGameInterface, IPoker, IUpdate {
     private _sidePots = new Map<string, bigint>();
     private _winners = new Map<string, Winner>();
     private _currentRound: TexasHoldemRound;
+    private readonly _autoExpire = false;
 
     // Constructor
     constructor(
@@ -1317,10 +1318,10 @@ class TexasHoldemGame implements IDealerGameInterface, IPoker, IUpdate {
                 }
 
                 // Handle timeout
-                // if (_player.status === PlayerStatus.ACTIVE && this.expired(_player.address)) {
-                //     _player.updateStatus(PlayerStatus.SITTING_OUT);
-                //     _player.holeCards = undefined;
-                // }
+                if (this._autoExpire && _player.status === PlayerStatus.ACTIVE && this.expired(_player.address)) {
+                    _player.updateStatus(PlayerStatus.SITTING_OUT);
+                    _player.holeCards = undefined;
+                }
 
                 return {
                     address: _player.address,

--- a/pvm/ts/src/engine/texasHoldem.ts
+++ b/pvm/ts/src/engine/texasHoldem.ts
@@ -1317,10 +1317,10 @@ class TexasHoldemGame implements IDealerGameInterface, IPoker, IUpdate {
                 }
 
                 // Handle timeout
-                if (_player.status === PlayerStatus.ACTIVE && this.expired(_player.address)) {
-                    _player.updateStatus(PlayerStatus.SITTING_OUT);
-                    _player.holeCards = undefined;
-                }
+                // if (_player.status === PlayerStatus.ACTIVE && this.expired(_player.address)) {
+                //     _player.updateStatus(PlayerStatus.SITTING_OUT);
+                //     _player.holeCards = undefined;
+                // }
 
                 return {
                     address: _player.address,


### PR DESCRIPTION
<img width="902" height="394" alt="2025-07-17_06-10-24" src="https://github.com/user-attachments/assets/1da29997-75fe-4161-a97a-a37d10cedf60" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Disabled automatic handling of player timeouts during game state updates. Players will no longer have their status or cards changed automatically due to timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->