### PR TITLE
fix: improve buy-in amount handling in VacantPlayer component

### DIFF
--- a/ui/src/components/playPage/Players/VacantPlayer.tsx
+++ b/ui/src/components/playPage/Players/VacantPlayer.tsx
@@ -150,7 +150,8 @@ const VacantPlayer: React.FC<VacantPlayerProps> = memo(
                 setJoinError(err instanceof Error ? err.message : "Unknown error joining table");
                 setIsJoining(false);
             }
-        }, [userAddress, privateKey, tableId, index, onJoin, gameOptions?.maxPlayers]);
+        }, [userAddress, privateKey, tableId, index, onJoin, gameOptions?.maxPlayers, gameOptions?.maxBuyIn]);
+
 
         // Memoize container styles
         const containerStyle = useMemo(() => ({

--- a/ui/src/components/playPage/Players/VacantPlayer.tsx
+++ b/ui/src/components/playPage/Players/VacantPlayer.tsx
@@ -107,10 +107,17 @@ const VacantPlayer: React.FC<VacantPlayerProps> = memo(
                 return;
             }
 
-            const storedAmount = localStorage.getItem("buy_in_amount");
-            if (!storedAmount) {
-                setJoinError("Missing buy-in amount");
-                return;
+            let buyInAmount = localStorage.getItem("buy_in_amount");
+            if (!buyInAmount) {
+                // No saved amount, use max buy-in from game options
+                const maxBuyInWei = gameOptions?.maxBuyIn;
+                if (!maxBuyInWei) {
+                    setJoinError("Unable to determine buy-in amount");
+                    return;
+                }
+                // Convert from Wei to regular units and save it
+                buyInAmount = ethers.formatUnits(maxBuyInWei, 18);
+                localStorage.setItem("buy_in_amount", buyInAmount);
             }
 
             setIsJoining(true);
@@ -119,7 +126,7 @@ const VacantPlayer: React.FC<VacantPlayerProps> = memo(
 
             try {
                 // Convert amount to Wei for the join function
-                const buyInWei = ethers.parseUnits(storedAmount, 18).toString();
+                const buyInWei = ethers.parseUnits(buyInAmount, 18).toString();
                 
                 // Use actual maxPlayers from game options, fallback to 9 if not available
                 const maxPlayers = gameOptions?.maxPlayers || 9;


### PR DESCRIPTION
<img width="2716" height="1194" alt="2025-07-21_16-32-19" src="https://github.com/user-attachments/assets/fb14b559-4e4b-42f3-b740-7107c90df912" />
<img width="1419" height="1638" alt="2025-07-21_16-45-32" src="https://github.com/user-attachments/assets/2879ef10-4640-45e5-8fe7-248d1cbde69a" />


Now when users join a table directly via a link and there's no saved buy-in amount, the system will automatically use the max buy-in from the game options and save it to localStorage. This prevents the "missing buy-in amount"
  error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing buy-in amounts by introducing a fallback mechanism that retrieves the maximum buy-in from game options if not found in local storage. This ensures smoother seat confirmation and reduces errors related to buy-in retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->