### PR TITLE
Added subscribeToTable so it reloads the game state if subscribeToTab…

### DIFF
--- a/ui/src/components/playPage/Table.tsx
+++ b/ui/src/components/playPage/Table.tsx
@@ -578,7 +578,7 @@ const Table = React.memo(() => {
         if (id) {
             subscribeToTable(id);
         }
-    }, [id]);
+    }, [id, subscribeToTable]);
 
 
 


### PR DESCRIPTION
stupid lol - performance optimisation was the source of the bug.
the useEffect captures the first version of subscribeToTable when the component mounts. so even if the GameStateContext creates a new version of subscribeToTable (due to state changes), the useEffect keeps using the old, stale version that is saved in useCallback which we implemented to stop unnecessary rendering.

The fix: 
slightly more aggressive on table state changes, 
Added subscribeToTable to the get game state dependance array, so it reloads and guarantees the latest state and not a state sitting inside useCalback function

I have played 10 rounds and it seems fixed. hmmm.... 

I'm pretty sure this is the bug, because now we have closure and always getting the latest game state no matter what. and no old game state hidden inside a useCallback.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table subscription behavior to ensure updates occur reliably when relevant data changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->