### PR TITLE
17 withdraw

### DIFF
--- a/contracts/test/Bridge.ts
+++ b/contracts/test/Bridge.ts
@@ -7,17 +7,17 @@ describe("Bridge", () => {
     const USDC_ADDRESS = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
     const UNISWAP_ROUTER = "0xE592427A0AEce92De3Edee1F18E0157C05861564";
     const WETH_ADDRESS = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
-    
+
     const fixture = async () => {
         const [owner, otherAccount, validator] = await hre.ethers.getSigners();
 
         // Get USDC interface
         const usdc = await ethers.getContractAt("IERC20", USDC_ADDRESS);
-        
+
         // Deploy mock WETH for testing
         const MockToken = await hre.ethers.getContractFactory("MockToken");
         const weth = await MockToken.deploy("Wrapped Ether", "WETH");
-        
+
         // Deploy mock Uniswap router
         const MockRouter = await hre.ethers.getContractFactory("MockUniswapRouter");
         const router = await MockRouter.deploy();
@@ -36,7 +36,7 @@ describe("Bridge", () => {
             params: ["0x47ac0Fb4F2D84898e4D9E7b4DaB3C24507a6D503"], // Binance account with USDC
         });
         const whale = await ethers.getSigner("0x47ac0Fb4F2D84898e4D9E7b4DaB3C24507a6D503");
-        
+
         // Send some ETH to whale for gas
         await owner.sendTransaction({
             to: whale.address,
@@ -47,7 +47,7 @@ describe("Bridge", () => {
         const amount = ethers.parseUnits("1000", 6); // USDC has 6 decimals
         await usdc.connect(whale).transfer(otherAccount.address, amount);
         await usdc.connect(whale).transfer(validator.address, amount);
-        
+
         // Approve bridge for USDC
         await usdc.connect(otherAccount).approve(await bridge.getAddress(), amount);
         await usdc.connect(validator).approve(await vault.getAddress(), amount);
@@ -58,11 +58,11 @@ describe("Bridge", () => {
     describe("Deployment", () => {
         it("Should deploy with correct parameters", async () => {
             const { bridge, usdc, router, vault } = await loadFixture(fixture);
-            
+
             expect(await bridge.underlying()).to.equal(USDC_ADDRESS);
             expect(await bridge.router()).to.equal(await router.getAddress());
             expect(await bridge.vault()).to.equal(await vault.getAddress());
-            
+
             expect(await bridge.name()).to.equal("USD Coin Bridge");
             expect(await bridge.symbol()).to.equal("USDCb");
             expect(await bridge.decimals()).to.equal(6);
@@ -73,11 +73,11 @@ describe("Bridge", () => {
         it("Should allow direct USDC deposits", async () => {
             const { bridge, otherAccount } = await loadFixture(fixture);
             const amount = ethers.parseUnits("100", 6);
-            
+
             await expect(bridge.connect(otherAccount).depositUnderlying(amount, "0xC84737526E425D7549eF20998Fa992f88EAC2484"))
                 .to.emit(bridge, "Deposited")
                 .withArgs(otherAccount.address, amount, 1);
-            
+
             const deposit = await bridge.deposits(0);
             expect(deposit.account).to.equal(otherAccount.address);
             expect(deposit.amount).to.equal(amount);
@@ -92,18 +92,18 @@ describe("Bridge", () => {
             const routerAddress = await router.getAddress();
             const depositAmount = ethers.parseEther("1"); // 1 WETH
             const expectedUsdc = ethers.parseUnits("2000", 6); // Mocked swap rate: 1 ETH = 2000 USDC
-            
+
             // Mint WETH to the test account
             await weth.mint(otherAccount.address, depositAmount);
-            
+
             // Approve WETH for both Bridge and Router
             await weth.connect(otherAccount).approve(bridgeAddress, depositAmount);
             await weth.connect(otherAccount).approve(routerAddress, depositAmount);
-            
+
             await expect(bridge.connect(otherAccount).deposit(depositAmount, otherAccount.address, await weth.getAddress()))
                 .to.emit(bridge, "Deposited")
                 .withArgs(otherAccount.address, expectedUsdc, 1);
-            
+
             const deposit = await bridge.deposits(0);
             expect(deposit.account).to.equal(otherAccount.address);
             expect(deposit.amount).to.equal(expectedUsdc);
@@ -118,16 +118,16 @@ describe("Bridge", () => {
         //         await vault.getAddress(), 
         //         ethers.ZeroAddress
         //     );
-            
+
         //     const depositAmount = ethers.parseUnits("100", 6); // 100 USDC
-            
+
         //     // Approve and deposit USDC directly
         //     await usdc.connect(otherAccount).approve(await newBridge.getAddress(), depositAmount);
-            
+
         //     await expect(newBridge.connect(otherAccount).deposit(depositAmount, otherAccount.address, USDC_ADDRESS))
         //         .to.emit(newBridge, "Deposited")
         //         .withArgs(otherAccount.address, depositAmount, 1);
-            
+
         //     const deposit = await newBridge.deposits(0);
         //     expect(deposit.account).to.equal(otherAccount.address);
         //     expect(deposit.amount).to.equal(depositAmount);
@@ -139,7 +139,7 @@ describe("Bridge", () => {
         it("Should allow withdrawals with valid signature", async () => {
             const { bridge, usdc, otherAccount, validator, vault } = await loadFixture(fixture);
             const amount = ethers.parseUnits("100", 6);
-            
+
             // Setup validator
             await vault.connect(validator).stake(amount);
             expect(await vault.balanceOf(validator.address)).to.equal(amount);
@@ -147,7 +147,7 @@ describe("Bridge", () => {
 
             // First deposit
             await bridge.connect(otherAccount).depositUnderlying(amount);
-            
+
             // Create withdrawal signature
             const nonce = ethers.id("unique_nonce");
             const messageHash = ethers.solidityPackedKeccak256(
@@ -155,12 +155,12 @@ describe("Bridge", () => {
                 [otherAccount.address, amount, nonce]
             );
             const signature = await validator.signMessage(ethers.getBytes(messageHash));
-            
+
             // Withdraw
             await expect(bridge.connect(otherAccount).withdraw(amount, otherAccount.address, nonce, signature))
                 .to.emit(bridge, "Withdrawn")
                 .withArgs(otherAccount.address, amount, nonce);
-            
+
             expect(await bridge.totalDeposits()).to.equal(0);
             expect(await usdc.balanceOf(otherAccount.address)).to.be.approximately(ethers.parseUnits("1000", 6), 100000n);
         });
@@ -173,18 +173,18 @@ describe("Bridge", () => {
             await vault.connect(validator).stake(amount);
             expect(await vault.balanceOf(validator.address)).to.equal(amount);
             expect(await vault.isValidator(validator.address)).to.be.true;
-            
+
             await bridge.connect(otherAccount).depositUnderlying(amount);
-            
+
             const nonce = ethers.id("unique_nonce");
             const messageHash = ethers.solidityPackedKeccak256(
                 ["address", "uint256", "bytes32"],
                 [otherAccount.address, amount, nonce]
             );
             const signature = await validator.signMessage(ethers.getBytes(messageHash));
-            
+
             await bridge.connect(otherAccount).withdraw(amount, otherAccount.address, nonce, signature);
-            
+
             await expect(
                 bridge.connect(otherAccount).withdraw(amount, otherAccount.address, nonce, signature)
             ).to.be.revertedWith("withdraw: nonce already used");
@@ -196,16 +196,16 @@ describe("Bridge", () => {
             const { bridge, usdc, otherAccount } = await loadFixture(fixture);
             const depositAmount = ethers.parseUnits("100", 6);
             const extraAmount = ethers.parseUnits("50", 6);
-            
+
             // Regular deposit
             await bridge.connect(otherAccount).depositUnderlying(depositAmount);
-            
+
             // Send extra USDC directly to bridge
             await usdc.connect(otherAccount).transfer(await bridge.getAddress(), extraAmount);
-            
+
             // Emergency withdraw should only take excess
             await bridge.emergencyWithdraw();
-            
+
             const bridgeBalance = await usdc.balanceOf(await bridge.getAddress());
             expect(bridgeBalance).to.equal(depositAmount);
             expect(await bridge.totalDeposits()).to.equal(depositAmount);

--- a/pvm/ts/package.json
+++ b/pvm/ts/package.json
@@ -13,7 +13,7 @@
         "sign": "npx ts-node scripts/sign.ts"
     },
     "dependencies": {
-        "@bitcoinbrisbane/block52": "1.0.161",
+        "@bitcoinbrisbane/block52": "1.2.1",
         "@types/cors": "^2.8.19",
         "@types/node": "^22.15.30",
         "@types/ws": "^8.18.1",

--- a/pvm/ts/package.json
+++ b/pvm/ts/package.json
@@ -13,7 +13,7 @@
         "sign": "npx ts-node scripts/sign.ts"
     },
     "dependencies": {
-        "@bitcoinbrisbane/block52": "1.0.156",
+        "@bitcoinbrisbane/block52": "1.0.161",
         "@types/cors": "^2.8.19",
         "@types/node": "^22.15.30",
         "@types/ws": "^8.18.1",

--- a/pvm/ts/package.json
+++ b/pvm/ts/package.json
@@ -13,7 +13,7 @@
         "sign": "npx ts-node scripts/sign.ts"
     },
     "dependencies": {
-        "@bitcoinbrisbane/block52": "1.2.1",
+        "@bitcoinbrisbane/block52": "1.2.2",
         "@types/cors": "^2.8.19",
         "@types/node": "^22.15.30",
         "@types/ws": "^8.18.1",

--- a/pvm/ts/src/commands/index.ts
+++ b/pvm/ts/src/commands/index.ts
@@ -31,6 +31,7 @@ import { SharedSecretCommand } from "./sharedSecretCommand";
 import { ShutdownCommand } from "./shutdownCommand";
 import { StartServerCommand } from "./startServerCommand";
 import { StopServerCommand } from "./stopServerCommand";
+import { WithdrawCommand } from "./withdrawCommand";
 import { ISignedResponse } from "./interfaces";
 
 export {
@@ -65,7 +66,8 @@ export {
     ShutdownCommand,
     StartServerCommand,
     StopServerCommand,
-    TransferCommand
+    TransferCommand,
+    WithdrawCommand
 };
 
 // TypeScript's isolatedModules flag requires type-only exports to use 'export type'

--- a/pvm/ts/src/commands/mintCommand.ts
+++ b/pvm/ts/src/commands/mintCommand.ts
@@ -35,11 +35,6 @@ export class MintCommand implements ISignedCommand<Transaction> {
         const bridgeAbi = ["function deposits(uint256) view returns (address account, uint256 amount)", "function underlying() view returns (address)"];
         this.underlyingAssetAbi = ["function decimals() view returns (uint8)"];
 
-        // const baseRPCUrl = process.env.RPC_URL;
-        // this.provider = new JsonRpcProvider(baseRPCUrl, undefined, {
-        //     staticNetwork: true
-        // });
-
         this.mempool = getMempoolInstance();
         this.transactionManagement = getTransactionInstance();
 
@@ -97,7 +92,8 @@ export class MintCommand implements ISignedCommand<Transaction> {
             const underlyingAsset = new ethers.Contract(underlyingAssetAddress, this.underlyingAssetAbi, this.provider);
             underlyingAssetDecimals = await underlyingAsset.decimals();
         }
-        const value: bigint = NativeToken.convertFromDecimals(amount, 6n);
+
+        const value: bigint = NativeToken.convertFromDecimals(amount, underlyingAssetDecimals);
         console.log("💰 Converted value:", {
             original: amount.toString(),
             converted: value.toString(),

--- a/pvm/ts/src/commands/signCommand.ts
+++ b/pvm/ts/src/commands/signCommand.ts
@@ -1,11 +1,9 @@
-
 import { createSign } from "crypto";
 import { ICommand } from "./interfaces";
 
 export class SignCommand implements ICommand<String> {
-
     private privateKey: string;
-    private hashAlgorithm: string = 'SHA256';
+    private hashAlgorithm: string = "SHA256";
 
     constructor(readonly message: string) {
         this.message = message;
@@ -23,7 +21,7 @@ IGxwPjFJZyl5BbHKhgjZBBkGieTthxtX0FSOB3Pcy/W8ZMkP6AvUMqZ7
         sign.end();
 
         // Sign the message using the private key
-        const signature = sign.sign(this.privateKey, 'hex');
+        const signature = sign.sign(this.privateKey, "hex");
         return signature;
     }
 }

--- a/pvm/ts/src/commands/withdrawCommand.ts
+++ b/pvm/ts/src/commands/withdrawCommand.ts
@@ -1,10 +1,10 @@
-import { TransactionResponse } from "@bitcoinbrisbane/block52";
+import { WithdrawResponse } from "@bitcoinbrisbane/block52";
 import { ICommand, ISignedResponse } from "./interfaces";
 import { AccountCommand } from "./accountCommand";
 import { Contract, ethers, InterfaceAbi } from "ethers";
 import { CONTRACT_ADDRESSES } from "../core/constants";
 
-export class WithdrawCommand implements ICommand<ISignedResponse<TransactionResponse>> {
+export class WithdrawCommand implements ICommand<ISignedResponse<WithdrawResponse>> {
 
     private readonly accountCommand: AccountCommand = new AccountCommand(this.from, this.privateKey);
     private readonly bridge: Contract;
@@ -13,30 +13,30 @@ export class WithdrawCommand implements ICommand<ISignedResponse<TransactionResp
     /**
      * Creates a new WithdrawCommand instance.
      * @param from The address sending the funds.
-     * @param to The address receiving the funds.
-     * @param amount The amount of funds to transfer.
+     * @param receiver The address receiving the funds.
+     * @param amount The amount of funds to withdraw.
      * @param nonce The nonce for the transaction.
-     * @param privateKey The private key of the sender's account.
+     * @param privateKey The private key of the validator.
      */
     constructor(
         private readonly from: string,
-        private readonly to: string,
+        private readonly receiver: string,
         private readonly amount: bigint,
         private readonly nonce: number,
         private readonly privateKey: string
     ) {
-        console.log(`Creating WithdrawCommand: from=${from}, to=${to}, amount=${amount}`);
+        console.log(`Creating WithdrawCommand: from=${from}, receiver=${receiver}, amount=${amount}`);
 
         if (!privateKey) {
             throw new Error("Private key must be provided");
         }
 
-        const bridgeAbi = ["function deposits(uint256) view returns (address account, uint256 amount)", "function underlying() view returns (address)"];
+        const bridgeAbi = ["function withdraw(uint256 amount, address receiver, bytes32 nonce, bytes calldata signature) external", "function underlying() view returns (address)"];
         this.underlyingAssetAbi = ["function decimals() view returns (uint8)"];
-        this.bridge = new ethers.Contract(CONTRACT_ADDRESSES.bridgeAddress, bridgeAbi, this.provider);
+        this.bridge = new ethers.Contract(CONTRACT_ADDRESSES.bridgeAddress, bridgeAbi);
     }
 
-    public async execute(): Promise<ISignedResponse<TransactionResponse>> {
+    public async execute(): Promise<ISignedResponse<WithdrawResponse>> {
         if (!Number.isInteger(this.nonce) || this.nonce < 0) {
             throw new Error("Invalid nonce: must be a non-negative integer");
         }
@@ -56,19 +56,7 @@ export class WithdrawCommand implements ICommand<ISignedResponse<TransactionResp
             throw new Error("Insufficient balance");
         }
 
-        // const transaction = new Transaction(
-        //     this.from,
-        //     this.to,
-        //     this.amount,
-        //     this.nonce,
-        //     KEYS.WITHDRAW_ACTION,
-        //     PlayerActionType.WITHDRAW
-        // );
 
-        // const performActionCommand = new PerformActionCommandWithResult(
-        //     transaction,
-        //     this.privateKey
-        // );
 
         // const signedResponse = await performActionCommand.execute();
         // return signResult(signedResponse, this.privateKey);

--- a/pvm/ts/src/commands/withdrawCommand.ts
+++ b/pvm/ts/src/commands/withdrawCommand.ts
@@ -75,7 +75,7 @@ export class WithdrawCommand implements ICommand<ISignedResponse<WithdrawRespons
         const encodedData = params.toString();
 
         console.log("📝 Creating transaction...");
-        const withdrawTx: Transaction = await Transaction.create(fromAccount.address, CONTRACT_ADDRESSES.bridgeAddress, this.amount, BigInt(this.nonce), this.privateKey, encodedData);
+        const withdrawTx: Transaction = await Transaction.create(CONTRACT_ADDRESSES.bridgeAddress, this.from, this.amount, BigInt(this.nonce), this.privateKey, encodedData);
 
         console.log("📨 Sending to mempool...");
         await this.mempool.add(withdrawTx);

--- a/pvm/ts/src/commands/withdrawCommand.ts
+++ b/pvm/ts/src/commands/withdrawCommand.ts
@@ -57,10 +57,12 @@ export class WithdrawCommand implements ICommand<ISignedResponse<WithdrawRespons
         }
 
         // Create withdrawal signature
-        const withdraw_nonce = ethers.id("unique_nonce");
+        // Unique, unpredictable nonce (bytes32)
+        const withdraw_nonce = ethers.hexlify(ethers.randomBytes(32));
+        // Bind the signature to the sender to prevent misuse
         const messageHash = ethers.solidityPackedKeccak256(
-            ["address", "uint256", "bytes32"],
-            [this.receiver, this.amount, withdraw_nonce]
+            ["address", "address", "uint256", "bytes32"],
+            [this.from, this.receiver, this.amount, withdraw_nonce]
         );
 
         const validator = new ethers.Wallet(this.privateKey);

--- a/pvm/ts/src/commands/withdrawCommand.ts
+++ b/pvm/ts/src/commands/withdrawCommand.ts
@@ -1,0 +1,78 @@
+import { TransactionResponse } from "@bitcoinbrisbane/block52";
+import { ICommand, ISignedResponse } from "./interfaces";
+import { AccountCommand } from "./accountCommand";
+import { Contract, ethers, InterfaceAbi } from "ethers";
+import { CONTRACT_ADDRESSES } from "../core/constants";
+
+export class WithdrawCommand implements ICommand<ISignedResponse<TransactionResponse>> {
+
+    private readonly accountCommand: AccountCommand = new AccountCommand(this.from, this.privateKey);
+    private readonly bridge: Contract;
+    private readonly underlyingAssetAbi: InterfaceAbi;
+    
+    /**
+     * Creates a new WithdrawCommand instance.
+     * @param from The address sending the funds.
+     * @param to The address receiving the funds.
+     * @param amount The amount of funds to transfer.
+     * @param nonce The nonce for the transaction.
+     * @param privateKey The private key of the sender's account.
+     */
+    constructor(
+        private readonly from: string,
+        private readonly to: string,
+        private readonly amount: bigint,
+        private readonly nonce: number,
+        private readonly privateKey: string
+    ) {
+        console.log(`Creating WithdrawCommand: from=${from}, to=${to}, amount=${amount}`);
+
+        if (!privateKey) {
+            throw new Error("Private key must be provided");
+        }
+
+        const bridgeAbi = ["function deposits(uint256) view returns (address account, uint256 amount)", "function underlying() view returns (address)"];
+        this.underlyingAssetAbi = ["function decimals() view returns (uint8)"];
+        this.bridge = new ethers.Contract(CONTRACT_ADDRESSES.bridgeAddress, bridgeAbi, this.provider);
+    }
+
+    public async execute(): Promise<ISignedResponse<TransactionResponse>> {
+        if (!Number.isInteger(this.nonce) || this.nonce < 0) {
+            throw new Error("Invalid nonce: must be a non-negative integer");
+        }
+        console.log(`Executing withdraw command...`);
+
+        const accountResponse = await this.accountCommand.execute();
+        const fromAccount = accountResponse.data;
+        console.log(`Account balance for ${this.from}: ${fromAccount.balance} ${fromAccount.nonce}`);
+
+        if (this.nonce !== fromAccount.nonce) {
+            console.log(`Invalid nonce: expected=${fromAccount.nonce}, provided=${this.nonce}`);
+            throw new Error("Invalid nonce");
+        }
+
+        if (this.amount > fromAccount.balance) {
+            console.log(`Insufficient balance: required=${this.amount}, available=${fromAccount.balance}`);
+            throw new Error("Insufficient balance");
+        }
+
+        // const transaction = new Transaction(
+        //     this.from,
+        //     this.to,
+        //     this.amount,
+        //     this.nonce,
+        //     KEYS.WITHDRAW_ACTION,
+        //     PlayerActionType.WITHDRAW
+        // );
+
+        // const performActionCommand = new PerformActionCommandWithResult(
+        //     transaction,
+        //     this.privateKey
+        // );
+
+        // const signedResponse = await performActionCommand.execute();
+        // return signResult(signedResponse, this.privateKey);
+
+        throw new Error("WithdrawCommand is not yet implemented");
+    }
+}

--- a/pvm/ts/src/commands/withdrawCommand.ts
+++ b/pvm/ts/src/commands/withdrawCommand.ts
@@ -1,10 +1,11 @@
 import { KEYS, WithdrawResponse } from "@bitcoinbrisbane/block52";
 import { ICommand, ISignedResponse } from "./interfaces";
 import { AccountCommand } from "./accountCommand";
-import { Contract, ethers, InterfaceAbi } from "ethers";
+import { Contract, ethers, InterfaceAbi, Wallet } from "ethers";
 import { CONTRACT_ADDRESSES } from "../core/constants";
 import { Transaction } from "../models/transaction";
 import { getMempoolInstance, Mempool } from "../core/mempool";
+import { signResult } from "./abstractSignedCommand";
 
 export class WithdrawCommand implements ICommand<ISignedResponse<WithdrawResponse>> {
 
@@ -87,14 +88,15 @@ export class WithdrawCommand implements ICommand<ISignedResponse<WithdrawRespons
         console.log("📨 Sending to mempool...");
         await this.mempool.add(withdrawTx);
 
-        const walletResponse = {
-            from: this.from,
+        const walletResponse: WithdrawResponse = {
+            nonce: withdraw_nonce,
             to: this.receiver,
-            amount: this.amount,
-            nonce: this.nonce,
-            privateKey: this.privateKey,
-            withdrawNonce: withdraw_nonce,
-            signature: signature
+            from: this.from,
+            value: this.amount.toString(),
+            hash: withdrawTx.hash,
+            signature: signature,
+            timestamp: Date.now().toString(),
+            withdrawSignature: signature,
         }
 
         return signResult(walletResponse, this.privateKey);

--- a/pvm/ts/src/rpc.ts
+++ b/pvm/ts/src/rpc.ts
@@ -381,6 +381,17 @@ export class RPC {
                     break;
                 }
 
+                case RPCMethods.WITHDRAW: {
+                    if (request.params?.length !== 4) {
+                        return makeErrorRPCResponse(id, "Invalid params");
+                    }
+                    const [from, receiver, amountString, nonce] = request.params as RPCRequestParams[RPCMethods.WITHDRAW];
+                    const amount = BigInt(amountString);    // JSON doesn't allow BigInts
+                    const command = new WithdrawCommand(from, receiver, amount, Number(nonce), validatorPrivateKey);
+                    result = await command.execute();
+                    break;
+                }
+
                 default:
                     return makeErrorRPCResponse(id, "Method not found");
             }

--- a/pvm/ts/src/rpc.ts
+++ b/pvm/ts/src/rpc.ts
@@ -29,7 +29,8 @@ import {
     ShutdownCommand,
     StartServerCommand,
     StopServerCommand,
-    TransferCommand
+    TransferCommand,
+    WithdrawCommand
 } from "./commands";
 
 import { makeErrorRPCResponse } from "./types/response";

--- a/pvm/ts/src/types/rpc.ts
+++ b/pvm/ts/src/types/rpc.ts
@@ -31,7 +31,8 @@ export const WRITE_METHODS = [
     RPCMethods.NEW_HAND,
     RPCMethods.NEW_TABLE,
     RPCMethods.PERFORM_ACTION,
-    RPCMethods.TRANSFER
+    RPCMethods.TRANSFER,
+    RPCMethods.WITHDRAW
 ];
 
 export const CONTROL_METHODS = [

--- a/pvm/ts/yarn.lock
+++ b/pvm/ts/yarn.lock
@@ -278,10 +278,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bitcoinbrisbane/block52@1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@bitcoinbrisbane/block52/-/block52-1.2.1.tgz#9ceb0ea7750adda286fb45eea9eaac8582a83a3b"
-  integrity sha512-DVq2ACu+bwfvTpaTevx7KnNG3j+oNg9So73gFJNUIJ8g7odNBtp/GJ2t8t/DhE2w5RUXbDWJBPa2wvOIF/JEvg==
+"@bitcoinbrisbane/block52@1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@bitcoinbrisbane/block52/-/block52-1.2.2.tgz#cf895e4c5680cc59b818d3e1b7ce8ca84794e589"
+  integrity sha512-V/nkNyjsMddfefoQAsOUpufNsKQT49j1CskURW03xChrVCB8knJEUFY4gZdi8MSLwUkmDxiB3AoPS+p5IAc/WQ==
   dependencies:
     axios "^1.8.1"
     bigunit "^1.2.5"

--- a/pvm/ts/yarn.lock
+++ b/pvm/ts/yarn.lock
@@ -278,10 +278,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bitcoinbrisbane/block52@1.0.156":
-  version "1.0.156"
-  resolved "https://registry.yarnpkg.com/@bitcoinbrisbane/block52/-/block52-1.0.156.tgz#49680a22cf55693938614da17fa90ac176a9ed7b"
-  integrity sha512-lYixzZ69P1q9KdV+AYwjTxrbcD9OEvInY85sw/u9yUK7zkMcai6NmVQ/EjCgyLfeRhwnIxrgzHlOnD+pdpOq8Q==
+"@bitcoinbrisbane/block52@1.0.161":
+  version "1.1.161"
+  resolved "https://registry.yarnpkg.com/@bitcoinbrisbane/block52/-/block52-1.1.161.tgz#2371ea5e084dc6d23c0c6dee87beb40e326f9956"
+  integrity sha512-PwnXfpEwND9PZmmyFVexqb+NJtLbARumUlaUHp7dsF8rH5uG+ReAV3o9TmlKUeolDo7tUGuQbjoDO2Dz4JC/LQ==
   dependencies:
     axios "^1.8.1"
     bigunit "^1.2.5"

--- a/pvm/ts/yarn.lock
+++ b/pvm/ts/yarn.lock
@@ -278,10 +278,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bitcoinbrisbane/block52@1.0.161":
-  version "1.1.161"
-  resolved "https://registry.yarnpkg.com/@bitcoinbrisbane/block52/-/block52-1.1.161.tgz#2371ea5e084dc6d23c0c6dee87beb40e326f9956"
-  integrity sha512-PwnXfpEwND9PZmmyFVexqb+NJtLbARumUlaUHp7dsF8rH5uG+ReAV3o9TmlKUeolDo7tUGuQbjoDO2Dz4JC/LQ==
+"@bitcoinbrisbane/block52@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@bitcoinbrisbane/block52/-/block52-1.2.1.tgz#9ceb0ea7750adda286fb45eea9eaac8582a83a3b"
+  integrity sha512-DVq2ACu+bwfvTpaTevx7KnNG3j+oNg9So73gFJNUIJ8g7odNBtp/GJ2t8t/DhE2w5RUXbDWJBPa2wvOIF/JEvg==
   dependencies:
     axios "^1.8.1"
     bigunit "^1.2.5"

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bitcoinbrisbane/block52",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "author": "@bitcoinbrisbane",
     "license": "MIT",
     "description": "SDK for interacting with the Block52 Node",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bitcoinbrisbane/block52",
-    "version": "1.1.161",
+    "version": "1.2.1",
     "author": "@bitcoinbrisbane",
     "license": "MIT",
     "description": "SDK for interacting with the Block52 Node",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bitcoinbrisbane/block52",
-    "version": "1.0.160",
+    "version": "1.1.161",
     "author": "@bitcoinbrisbane",
     "license": "MIT",
     "description": "SDK for interacting with the Block52 Node",

--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -6,7 +6,8 @@ import {
     PerformActionResponse,
     PlayerActionType,
     TexasHoldemStateDTO,
-    TransactionResponse
+    TransactionResponse,
+    WithdrawResponse
 } from "./types/game";
 import { RPCMethods, RPCRequest, RPCResponse } from "./types/rpc";
 import { KEYS } from "./index";
@@ -38,6 +39,7 @@ export interface IClient {
     sendBlock(blockHash: string, block: string): Promise<void>;
     sendBlockHash(blockHash: string, nodeUrl: string): Promise<void>;
     transfer(to: string, amount: string, nonce?: number, data?: string): Promise<TransactionResponse>;
+    withdraw(amount: string, from: string, receiver?: string, nonce?: number): Promise<WithdrawResponse>;
 }
 
 /**
@@ -621,6 +623,37 @@ export class NodeRpcClient implements IClient {
             id: this.getRequestId(),
             method: RPCMethods.PERFORM_ACTION,
             params: [address, gameAddress, NonPlayerActionType.DEAL, "0", nonce, index, encodedData], // [from, to, action, amount, nonce, index, data]
+            signature: signature
+        });
+
+        return body.result.data;
+    }
+
+
+    /**
+     * Withdraw funds from an account
+     * @param amount The amount to withdraw
+     * @param from The address to withdraw from
+     * @param receiver The address to receive the funds (optional)
+     * @param nonce The nonce of the transaction (optional)
+     * @returns A Promise that resolves when the request is complete
+     */
+    public async withdraw(amount: string, from?: string, receiver?: string, nonce?: number): Promise<WithdrawResponse> {
+        from = from || this.getAddress();
+        if (!nonce) {
+            nonce = await this.getNonce(from);
+        }
+
+        if (!receiver) {
+            receiver = from; // If no receiver is specified, withdraw to the same address
+        }
+
+        const signature = await this.getSignature(nonce, [from, receiver, amount]);
+
+        const { data: body } = await axios.post(this.url, {
+            id: this.getRequestId(),
+            method: RPCMethods.WITHDRAW,
+            params: [from, receiver, amount, nonce],
             signature: signature
         });
 

--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -1,4 +1,4 @@
-import { AccountDTO, BlockDTO, TransactionDTO } from "./types/chain";
+import { AccountDTO, BlockDTO, TransactionDTO, WithdrawResponseDTO } from "./types/chain";
 import {
     GameOptionsResponse,
     LegalActionDTO,
@@ -7,7 +7,6 @@ import {
     PlayerActionType,
     TexasHoldemStateDTO,
     TransactionResponse,
-    WithdrawResponse
 } from "./types/game";
 import { RPCMethods, RPCRequest, RPCResponse } from "./types/rpc";
 import { KEYS } from "./index";
@@ -39,7 +38,7 @@ export interface IClient {
     sendBlock(blockHash: string, block: string): Promise<void>;
     sendBlockHash(blockHash: string, nodeUrl: string): Promise<void>;
     transfer(to: string, amount: string, nonce?: number, data?: string): Promise<TransactionResponse>;
-    withdraw(amount: string, from: string, receiver?: string, nonce?: number): Promise<WithdrawResponse>;
+    withdraw(amount: string, from: string, receiver?: string, nonce?: number): Promise<WithdrawResponseDTO>;
 }
 
 /**
@@ -638,7 +637,7 @@ export class NodeRpcClient implements IClient {
      * @param nonce The nonce of the transaction (optional)
      * @returns A Promise that resolves when the request is complete
      */
-    public async withdraw(amount: string, from?: string, receiver?: string, nonce?: number): Promise<WithdrawResponse> {
+    public async withdraw(amount: string, from?: string, receiver?: string, nonce?: number): Promise<WithdrawResponseDTO> {
         from = from || this.getAddress();
         if (!nonce) {
             nonce = await this.getNonce(from);

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -5,10 +5,16 @@ export * from "./client";
 
 export enum KEYS {
     ACTION_TYPE = "actiontype",
+    AMOUNT = "amount", // Used for both deposit and withdraw amounts
+    DEPOSIT_INDEX = "deposit-index",
     INDEX = "index",
+    NONCE = "nonce",
     PUBLIC_KEY = "publickey",
+    RECEIVER = "receiver",
     SEAT = "seat",
     SEED = "seed",
     TX_HASH = "txHash",
-    VALUE = "value"
+    VALUE = "value",
+    WITHDRAW_NONCE = "withdraw-nonce",
+    WITHDRAW_SIGNATURE = "withdraw-signature",
 }

--- a/sdk/src/types/chain.ts
+++ b/sdk/src/types/chain.ts
@@ -41,3 +41,12 @@ export type BurnResponseDTO = {
     };
     burnTransaction: TransactionDTO;
 };
+
+export type WithdrawResponseDTO = {
+    nonce: string;
+    receiver: string;
+    amount: string;
+    signature: string;
+    timestamp: string;
+    withdrawSignature: string;
+};

--- a/sdk/src/types/game.ts
+++ b/sdk/src/types/game.ts
@@ -198,3 +198,14 @@ export type PerformActionResponse= {
     timestamp: string;
     data?: string;
 }
+
+export type WithdrawResponse = {
+    nonce: string;
+    to: string;
+    from: string;
+    value: string;
+    hash: string;
+    signature: string;
+    timestamp: string;
+    withdrawSignature: string;
+}

--- a/sdk/src/types/game.ts
+++ b/sdk/src/types/game.ts
@@ -187,7 +187,7 @@ export type GameStateResponse = {
     state: TexasHoldemStateDTO;
 }
 
-export type PerformActionResponse= {
+export type PerformActionResponse = {
     state: TexasHoldemStateDTO;
     nonce: string;
     to: string;
@@ -197,15 +197,4 @@ export type PerformActionResponse= {
     signature: string;
     timestamp: string;
     data?: string;
-}
-
-export type WithdrawResponse = {
-    nonce: string;
-    to: string;
-    from: string;
-    value: string;
-    hash: string;
-    signature: string;
-    timestamp: string;
-    withdrawSignature: string;
 }

--- a/sdk/src/types/rpc.ts
+++ b/sdk/src/types/rpc.ts
@@ -51,7 +51,8 @@ export enum RPCMethods {
     SHUTDOWN = "shutdown",
     START = "start",
     STOP = "stop",
-    TRANSFER = "transfer"
+    TRANSFER = "transfer",
+    WITHDRAW = "withdraw"
 }
 
 export type RPCRequestParams = {
@@ -88,4 +89,5 @@ export type RPCRequestParams = {
     [RPCMethods.START]: []; // No parameters
     [RPCMethods.STOP]: []; // No parameters
     [RPCMethods.TRANSFER]: [string, string, string, number, string | null]; // [from, to, amount, nonce, data]
+    [RPCMethods.WITHDRAW]: [string, string, string, number]; // [from, to, amount, nonce]
 };


### PR DESCRIPTION
<img width="1439" height="830" alt="image" src="https://github.com/user-attachments/assets/46ca7bd2-c776-4be9-9541-5ff1ca060c39" />

Data to pass to the smart contract

```json
{
    "id": "1",
    "result": {
        "data": {
            "nonce": "0xc38cbf8419bade72f4402fdbb17f9910e856bc2d1e3cb7a62a7db10865fe3a60",
            "receiver": "0xE8DE79b707BfB7d8217cF0a494370A9cC251602C",
            "amount": "5950000000000000000",
            "signature": "0x8780fdba786ac672ee02018a37020643106499e88e72ff0e45c0de1f628a508f20d6cc298c24997ad4deca92bf64a5ee54c2ab17d0a614586933ba8dfda145ca1b",
            "timestamp": "1755225722359",
            "withdrawSignature": "0x8780fdba786ac672ee02018a37020643106499e88e72ff0e45c0de1f628a508f20d6cc298c24997ad4deca92bf64a5ee54c2ab17d0a614586933ba8dfda145ca1b"
        },
        "signature": "0x9fa1413acd88e586384e19a122a318df3ab5e395cdc62554fba7a79b45440ff061da5fb48577d3f728999fc47ee5411506c45d9e38424a07b2bf6c31517b87e31b"
    }
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added end-to-end withdrawal support: RPC method and SDK client call for withdrawing funds (optional receiver and nonce).
  - SDK returns a Withdraw response with signature and withdraw-specific fields; new keys added for integration.

- Refactor
  - Minting now respects token decimals for more accurate amount handling.

- Chores
  - Dependency updates and SDK version bump.

- Style
  - Minor formatting and whitespace cleanups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->