### PR TITLE
fix: include blinds in sumOfBets calculation and add test for bug 1111

### DIFF
--- a/pvm/ts/src/engine/texasHoldem.ts
+++ b/pvm/ts/src/engine/texasHoldem.ts
@@ -1487,7 +1487,7 @@ class TexasHoldemGame implements IDealerGameInterface, IPoker, IUpdate {
                     status: _player.status,
                     lastAction: lastAction,
                     legalActions: legalActions,
-                    sumOfBets: this.getPlayerTotalBets(_player.address).toString(),
+                    sumOfBets: this.getPlayerTotalBets(_player.address, this.currentRound, true).toString(), // Include blinds in JSON output
                     timeout: 0,
                     signature: ethers.ZeroHash
                 };
@@ -1520,7 +1520,7 @@ class TexasHoldemGame implements IDealerGameInterface, IPoker, IUpdate {
         };
 
         const nextPlayerToAct = this.findNextPlayerToActForRound(this.currentRound);
-        
+
         // Return the complete state DTO
         const state: TexasHoldemStateDTO = {
             type: this.type, // Todo remove this duplication

--- a/pvm/ts/tests/bugs.test.ts
+++ b/pvm/ts/tests/bugs.test.ts
@@ -23,6 +23,7 @@ import {
     test_1103_2,
     test_1120,
     test_1126,
+    test_1111,
 } from "./scenarios/data";
 
 // This test suite is for the Texas Holdem game engine, specifically for the Ante round in a heads-up scenario.
@@ -340,6 +341,113 @@ describe("Texas Holdem - Data driven", () => {
 
             // Game should still be in TURN round, not END
             expect(game.currentRound).toEqual(TexasHoldemRound.TURN);
+        });
+
+        it.only("should test bug 1111 - sumOfBets values for blinds", () => {
+            game = fromTestJson(test_1111);
+
+            console.log("=== BUG 1111: sumOfBets for Blinds ===");
+            console.log("Current round:", game.currentRound);
+            console.log("Pot total:", game.pot.toString());
+
+            // Define player addresses
+            const SEAT_1_SMALL_BLIND = "0xC84737526E425D7549eF20998Fa992f88EAC2484";
+            const SEAT_2_BIG_BLIND = "0xE8DE79b707BfB7d8217cF0a494370A9cC251602C";
+            const SEAT_3_CALLER = "0xd15df2C33Ed08041Efba88a3b13Afb47Ae0262A8";
+            const SEAT_4_DEALER = "0x4260E88e81E60113146092Fb9474b61C59f7552e";
+
+            // Expected values from the data
+            const SMALL_BLIND_AMOUNT = BigInt("100000000000000000000"); // 100 tokens
+            const BIG_BLIND_AMOUNT = BigInt("200000000000000000000");   // 200 tokens
+            const CALL_AMOUNT = BigInt("200000000000000000000");        // 200 tokens
+
+            // Check game state
+            expect(game.currentRound).toEqual(TexasHoldemRound.PREFLOP);
+            expect(game.pot).toEqual(BigInt("500000000000000000000")); // 100 + 200 + 200 = 500
+
+            // Test JSON output to verify sumOfBets property
+            console.log("=== TESTING JSON OUTPUT ===");
+            const gameJson = game.toJson();
+            console.log("Game JSON players with sumOfBets:");
+
+            // Find each player in the JSON and verify their sumOfBets
+            const jsonSmallBlindPlayer = gameJson.players.find((p: any) => p.address === SEAT_1_SMALL_BLIND);
+            const jsonBigBlindPlayer = gameJson.players.find((p: any) => p.address === SEAT_2_BIG_BLIND);
+            const jsonCallerPlayer = gameJson.players.find((p: any) => p.address === SEAT_3_CALLER);
+            const jsonDealerPlayer = gameJson.players.find((p: any) => p.address === SEAT_4_DEALER);
+
+            // Verify JSON objects have sumOfBets property
+            expect(jsonSmallBlindPlayer).toBeDefined();
+            expect(jsonSmallBlindPlayer?.sumOfBets).toBeDefined();
+            expect(jsonBigBlindPlayer).toBeDefined();
+            expect(jsonBigBlindPlayer?.sumOfBets).toBeDefined();
+            expect(jsonCallerPlayer).toBeDefined();
+            expect(jsonCallerPlayer?.sumOfBets).toBeDefined();
+            expect(jsonDealerPlayer).toBeDefined();
+            expect(jsonDealerPlayer?.sumOfBets).toBeDefined();
+
+            // Check sumOfBets values in JSON
+            console.log(`JSON SEAT_1 (Small Blind): sumOfBets=${jsonSmallBlindPlayer?.sumOfBets}`);
+            console.log(`JSON SEAT_2 (Big Blind): sumOfBets=${jsonBigBlindPlayer?.sumOfBets}`);
+            console.log(`JSON SEAT_3 (Caller): sumOfBets=${jsonCallerPlayer?.sumOfBets}`);
+            console.log(`JSON SEAT_4 (Dealer): sumOfBets=${jsonDealerPlayer?.sumOfBets}`);
+
+            // Assert JSON sumOfBets values match expectations
+            // These should be the CORRECT values - test will fail showing the bug
+            expect(jsonSmallBlindPlayer?.sumOfBets).toEqual("100000000000000000000"); // Should be 100 tokens
+            expect(jsonBigBlindPlayer?.sumOfBets).toEqual("200000000000000000000");   // Should be 200 tokens  
+            expect(jsonCallerPlayer?.sumOfBets).toEqual("200000000000000000000");     // ✅ Correct: Call bet is tracked
+            expect(jsonDealerPlayer?.sumOfBets).toEqual("0");                         // ✅ Correct: No bets
+
+            // Get all players
+            const smallBlindPlayer = game.getPlayer(SEAT_1_SMALL_BLIND);
+            const bigBlindPlayer = game.getPlayer(SEAT_2_BIG_BLIND);
+            const callerPlayer = game.getPlayer(SEAT_3_CALLER);
+            const dealerPlayer = game.getPlayer(SEAT_4_DEALER);
+
+            console.log("=== PLAYER STACKS AND BETS ===");
+
+            // Get total bets using game's method - check all rounds
+            const smallBlindTotalBets = game.getPlayerTotalBets(SEAT_1_SMALL_BLIND, game.currentRound, true); // includeBlinds = true
+            const bigBlindTotalBets = game.getPlayerTotalBets(SEAT_2_BIG_BLIND, game.currentRound, true); // includeBlinds = true  
+            const callerTotalBets = game.getPlayerTotalBets(SEAT_3_CALLER, game.currentRound, true); // includeBlinds = true
+            const dealerTotalBets = game.getPlayerTotalBets(SEAT_4_DEALER, game.currentRound, true); // includeBlinds = true
+
+            // Check small blind player
+            console.log(`SEAT_1 (Small Blind): Stack=${smallBlindPlayer.chips.toString()}, TotalBets=${smallBlindTotalBets.toString()}`);
+            expect(smallBlindPlayer.chips).toEqual(BigInt("9900000000000000000000")); // 10000 - 100 = 9900
+            // VERIFIED: This is correctly tracking 100000000000000000000 (100 tokens)
+            expect(smallBlindTotalBets).toEqual(SMALL_BLIND_AMOUNT); // This assertion passes - blind bets ARE tracked correctly
+
+            // Check big blind player  
+            console.log(`SEAT_2 (Big Blind): Stack=${bigBlindPlayer.chips.toString()}, TotalBets=${bigBlindTotalBets.toString()}`);
+            expect(bigBlindPlayer.chips).toEqual(BigInt("9800000000000000000000")); // 10000 - 200 = 9800
+            // VERIFIED: This is correctly tracking 200000000000000000000 (200 tokens)
+            expect(bigBlindTotalBets).toEqual(BIG_BLIND_AMOUNT); // This assertion passes - blind bets ARE tracked correctly
+
+            // Check caller player (this should work correctly)
+            console.log(`SEAT_3 (Caller): Stack=${callerPlayer.chips.toString()}, TotalBets=${callerTotalBets.toString()}`);
+            expect(callerPlayer.chips).toEqual(BigInt("9800000000000000000000")); // 10000 - 200 = 9800
+            expect(callerTotalBets).toEqual(CALL_AMOUNT); // This should work correctly
+
+            // Check dealer player (no bets yet)
+            console.log(`SEAT_4 (Dealer): Stack=${dealerPlayer.chips.toString()}, TotalBets=${dealerTotalBets.toString()}`);
+            expect(dealerPlayer.chips).toEqual(BigInt("10000000000000000000000")); // No change
+            expect(dealerTotalBets).toEqual(BigInt(0)); // Should be 0
+
+            console.log("=== BLIND BET TRACKING ===");
+            console.log("✅ Small blind bet IS correctly tracked by game.getPlayerTotalBets()");
+            console.log("✅ Big blind bet IS correctly tracked by game.getPlayerTotalBets()");
+            console.log("✅ Small blind bet IS now correctly tracked in JSON sumOfBets!");
+            console.log("✅ Big blind bet IS now correctly tracked in JSON sumOfBets!");
+            console.log("✅ Total pot equals sum of all bets: 100 + 200 + 200 = 500");
+
+            // Additional verification: total bets should equal pot
+            const totalPlayerBets = smallBlindTotalBets + bigBlindTotalBets + callerTotalBets + dealerTotalBets;
+            console.log(`Total player bets: ${totalPlayerBets.toString()}`);
+            expect(totalPlayerBets).toEqual(game.pot);
+
+            console.log("=== BUG 1111 RESULT: FIXED! JSON sumOfBets now includes blind bets! ===");
         });
     });
 });

--- a/pvm/ts/tests/scenarios/data.ts
+++ b/pvm/ts/tests/scenarios/data.ts
@@ -4144,3 +4144,211 @@ export const test_1126 = {
         "signature": "0xd15d17d01894120bd88787ec7837e491050cef23e8834cfaec36d0baf20bfa4f24e9fb8b617bf8f6ca6706308fdf0664c9b838dd3dbd51e61c4905f4e189fb581c"
     }
 }
+
+export const test_1111 = {
+    "id": "1",
+    "result": {
+        "data": {
+            "type": "sit-and-go",
+            "address": "0x4957e048d6468e06034d3eafc74d612033787d13",
+            "gameOptions": {
+                "minBuyIn": "1000000000000000000",
+                "maxBuyIn": "1000000000000000000",
+                "maxPlayers": 4,
+                "minPlayers": 4,
+                "smallBlind": "100000000000000000000",
+                "bigBlind": "200000000000000000000",
+                "timeout": 300000,
+                "type": "sit-and-go"
+            },
+            "smallBlindPosition": 1,
+            "bigBlindPosition": 2,
+            "dealer": 4,
+            "players": [
+                {
+                    "address": "0xC84737526E425D7549eF20998Fa992f88EAC2484",
+                    "seat": 1,
+                    "stack": "9900000000000000000000",
+                    "isSmallBlind": true,
+                    "isBigBlind": false,
+                    "isDealer": false,
+                    "holeCards": [
+                        "??",
+                        "??"
+                    ],
+                    "status": "active",
+                    "legalActions": [],
+                    "sumOfBets": "0",
+                    "timeout": 0,
+                    "signature": "0x0000000000000000000000000000000000000000000000000000000000000000"
+                },
+                {
+                    "address": "0xd15df2C33Ed08041Efba88a3b13Afb47Ae0262A8",
+                    "seat": 3,
+                    "stack": "9800000000000000000000",
+                    "isSmallBlind": false,
+                    "isBigBlind": false,
+                    "isDealer": false,
+                    "holeCards": [
+                        "??",
+                        "??"
+                    ],
+                    "status": "active",
+                    "lastAction": {
+                        "playerId": "0xd15df2C33Ed08041Efba88a3b13Afb47Ae0262A8",
+                        "seat": 3,
+                        "action": "call",
+                        "amount": "200000000000000000000",
+                        "round": "preflop",
+                        "index": 8,
+                        "timestamp": 1757291218029
+                    },
+                    "legalActions": [],
+                    "sumOfBets": "200000000000000000000",
+                    "timeout": 0,
+                    "signature": "0x0000000000000000000000000000000000000000000000000000000000000000"
+                },
+                {
+                    "address": "0x4260E88e81E60113146092Fb9474b61C59f7552e",
+                    "seat": 4,
+                    "stack": "10000000000000000000000",
+                    "isSmallBlind": false,
+                    "isBigBlind": false,
+                    "isDealer": true,
+                    "holeCards": [
+                        "6H",
+                        "JD"
+                    ],
+                    "status": "active",
+                    "legalActions": [
+                        {
+                            "action": "fold",
+                            "min": "0",
+                            "max": "0",
+                            "index": 9
+                        },
+                        {
+                            "action": "call",
+                            "min": "200000000000000000000",
+                            "max": "200000000000000000000",
+                            "index": 9
+                        },
+                        {
+                            "action": "raise",
+                            "min": "400000000000000000000",
+                            "max": "10000000000000000000000",
+                            "index": 9
+                        }
+                    ],
+                    "sumOfBets": "0",
+                    "timeout": 0,
+                    "signature": "0x0000000000000000000000000000000000000000000000000000000000000000"
+                },
+                {
+                    "address": "0xE8DE79b707BfB7d8217cF0a494370A9cC251602C",
+                    "seat": 2,
+                    "stack": "9800000000000000000000",
+                    "isSmallBlind": false,
+                    "isBigBlind": true,
+                    "isDealer": false,
+                    "holeCards": [
+                        "??",
+                        "??"
+                    ],
+                    "status": "active",
+                    "legalActions": [],
+                    "sumOfBets": "0",
+                    "timeout": 0,
+                    "signature": "0x0000000000000000000000000000000000000000000000000000000000000000"
+                }
+            ],
+            "communityCards": [],
+            "deck": "AH-2D-6H-5D-JS-AC-JD-4H-[4D]-8H-QC-KS-JC-QD-9H-2S-7H-AS-5S-QH-5C-3C-KH-6D-4C-9S-6C-4S-9C-8D-KD-AD-3D-7C-9D-TH-TS-5H-6S-3S-7D-2C-KC-TD-8C-JH-2H-3H-QS-TC-7S-8S",
+            "pots": [
+                "500000000000000000000"
+            ],
+            "lastActedSeat": 3,
+            "actionCount": 0,
+            "handNumber": 1,
+            "nextToAct": 4,
+            "previousActions": [
+                {
+                    "playerId": "0xC84737526E425D7549eF20998Fa992f88EAC2484",
+                    "seat": 1,
+                    "action": "join",
+                    "amount": "10000000000000000000000",
+                    "round": "ante",
+                    "index": 1,
+                    "timestamp": 1757290438029
+                },
+                {
+                    "playerId": "0xd15df2C33Ed08041Efba88a3b13Afb47Ae0262A8",
+                    "seat": 3,
+                    "action": "join",
+                    "amount": "10000000000000000000000",
+                    "round": "ante",
+                    "index": 2,
+                    "timestamp": 1757290468036
+                },
+                {
+                    "playerId": "0x4260E88e81E60113146092Fb9474b61C59f7552e",
+                    "seat": 4,
+                    "action": "join",
+                    "amount": "10000000000000000000000",
+                    "round": "ante",
+                    "index": 3,
+                    "timestamp": 1757290513038
+                },
+                {
+                    "playerId": "0xE8DE79b707BfB7d8217cF0a494370A9cC251602C",
+                    "seat": 2,
+                    "action": "join",
+                    "amount": "10000000000000000000000",
+                    "round": "ante",
+                    "index": 4,
+                    "timestamp": 1757290513038
+                },
+                {
+                    "playerId": "0xC84737526E425D7549eF20998Fa992f88EAC2484",
+                    "seat": 1,
+                    "action": "post-small-blind",
+                    "amount": "100000000000000000000",
+                    "round": "ante",
+                    "index": 5,
+                    "timestamp": 1757290513038
+                },
+                {
+                    "playerId": "0xE8DE79b707BfB7d8217cF0a494370A9cC251602C",
+                    "seat": 2,
+                    "action": "post-big-blind",
+                    "amount": "200000000000000000000",
+                    "round": "ante",
+                    "index": 6,
+                    "timestamp": 1757291023009
+                },
+                {
+                    "playerId": "0xd15df2C33Ed08041Efba88a3b13Afb47Ae0262A8",
+                    "seat": 3,
+                    "action": "deal",
+                    "amount": "",
+                    "round": "ante",
+                    "index": 7,
+                    "timestamp": 1757291218029
+                },
+                {
+                    "playerId": "0xd15df2C33Ed08041Efba88a3b13Afb47Ae0262A8",
+                    "seat": 3,
+                    "action": "call",
+                    "amount": "200000000000000000000",
+                    "round": "preflop",
+                    "index": 8,
+                    "timestamp": 1757291218029
+                }
+            ],
+            "round": "preflop",
+            "winners": [],
+            "signature": "0x0000000000000000000000000000000000000000000000000000000000000000"
+        },
+        "signature": "0xbc6da179d36ad465813eef0b5622484e796bbf10af9449191ed92fd0652c598a0ee2746bcee3de8ccb53b01778005310e96f5913af642d777981949f2194f3181c"
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected serialized Texas Hold’em state so each player’s total bets now include blinds, ensuring pot size and per‑player totals align from the start of the hand.

* **Tests**
  * Added a new regression scenario validating blind inclusion, pot composition, and per‑player bet totals.
  * Expanded test data set to cover the updated behavior and prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->