### PR TITLE
Test scenario: When a player has called a bet on the river he must show is cards at show down IF he has a hand better than other hands shown down. variation of 900#

### DIFF
--- a/pvm/ts/tests/test-unknown-when_a_player_has_called_a_bet_on_the_river_he_mus.test.ts
+++ b/pvm/ts/tests/test-unknown-when_a_player_has_called_a_bet_on_the_river_he_mus.test.ts
@@ -1,0 +1,51 @@
+import { NonPlayerActionType, PlayerActionType, TexasHoldemRound } from "@bitcoinbrisbane/block52";
+import TexasHoldemGame from "../src/engine/texasHoldem";
+import { baseGameConfig, gameOptions, ONE_HUNDRED_TOKENS, ONE_TOKEN, TWO_TOKENS } from "../src/engine/testConstants";
+
+describe("When a player has called a bet on the river he must show is cards at show down IF he has a hand better than other hands shown down. variation of 900#", () => {
+    const PLAYER_1 = "0x1111111111111111111111111111111111111111";
+    const PLAYER_2 = "0x2222222222222222222222222222222222222222";
+
+    let game: TexasHoldemGame;
+
+    beforeEach(() => {
+        game = TexasHoldemGame.fromJson(baseGameConfig, gameOptions);
+        
+        // Add players to the game
+        game.performAction(PLAYER_1, NonPlayerActionType.JOIN, 1, ONE_HUNDRED_TOKENS, "seat=1");
+        game.performAction(PLAYER_2, NonPlayerActionType.JOIN, 2, ONE_HUNDRED_TOKENS, "seat=2");
+    });
+
+    it("when a player has called a bet on the river he must show is cards at show down if he has a hand better than other hands shown down. variation of 900#", () => {
+        // Execute the setup actions
+        game.performAction(PLAYER_1, PlayerActionType.SMALL_BLIND, 3, ONE_TOKEN);
+        game.performAction(PLAYER_2, PlayerActionType.BIG_BLIND, 4, TWO_TOKENS);
+        game.performAction(PLAYER_1, NonPlayerActionType.DEAL, 5);
+        game.performAction(PLAYER_1, PlayerActionType.CALL, 6, ONE_TOKEN);
+        game.performAction(PLAYER_2, PlayerActionType.CHECK, 7, 0n);
+        game.performAction(PLAYER_1, PlayerActionType.CHECK, 8, 0n);
+        game.performAction(PLAYER_2, PlayerActionType.CHECK, 9, 0n);
+        game.performAction(PLAYER_1, PlayerActionType.CHECK, 10, 0n);
+        game.performAction(PLAYER_2, PlayerActionType.CHECK, 11, 0n);
+        game.performAction(PLAYER_1, PlayerActionType.BET, 12, TWO_TOKENS);
+        game.performAction(PLAYER_2, PlayerActionType.CALL, 13, TWO_TOKENS);
+
+        // Test showdown behavior
+        expect(game.currentRound).toEqual(TexasHoldemRound.SHOWDOWN);
+        
+        // The first player to act should only have SHOW as a legal action
+        // This is the core test - first to act cannot muck, must show
+        const firstPlayerActions = game.getLegalActions(PLAYER_1);
+        expect(firstPlayerActions).toBeDefined();
+        expect(firstPlayerActions.length).toEqual(1);
+        expect(firstPlayerActions[0].action).toEqual(PlayerActionType.SHOW);
+        
+        // Now perform the SHOW action to complete the test
+        game.performAction(PLAYER_1, PlayerActionType.SHOW, 14, 0n);
+        game.performAction(PLAYER_2, PlayerActionType.SHOW, 15, 0n);
+        
+        // Verify that the game state is consistent
+        expect(game.getPlayerCount()).toEqual(2);
+        expect(game.pot).toBeGreaterThan(0n);
+    });
+});


### PR DESCRIPTION
Automated test file generation for scenario: When a player has called a bet on the river he must show is cards at show down IF he has a hand better than other hands shown down. variation of 900#

Generated from poker scenario converter.