### PR TITLE
1158 sit go tournament not ending when only one player remains

### DIFF
--- a/pvm/ts/src/engine/actions/baseAction.ts
+++ b/pvm/ts/src/engine/actions/baseAction.ts
@@ -77,6 +77,12 @@ abstract class BaseAction {
         }
     }
 
+    protected validateNotInEndRound(): void {
+        if (this.game.currentRound === TexasHoldemRound.END) {
+            throw new Error(`Cannot ${this.type.toLowerCase()} in the end round.`);
+        }
+    }
+
     protected validateInSpecificRound(requiredRound: TexasHoldemRound): void {
         if (this.game.currentRound !== requiredRound) {
             throw new Error(`${this.type} can only be performed during ${requiredRound} round.`);

--- a/pvm/ts/src/engine/actions/betAction.ts
+++ b/pvm/ts/src/engine/actions/betAction.ts
@@ -2,7 +2,6 @@ import { PlayerActionType, TexasHoldemRound } from "@bitcoinbrisbane/block52";
 import { Player } from "../../models/player";
 import BaseAction from "./baseAction";
 import { IAction, Range } from "../types";
-import { BetManager } from "../managers/betManager";
 
 class BetAction extends BaseAction implements IAction {
     get type(): PlayerActionType {
@@ -13,9 +12,10 @@ class BetAction extends BaseAction implements IAction {
         // Check base conditions (hand active, player's turn, player active)
         super.verify(player);
 
-        // 1. Round state check: Cannot bet during ANTE or SHOWDOWN rounds
+        // 1. Round state check: Cannot bet during ANTE, SHOWDOWN, or END rounds
         this.validateNotInAnteRound();
         this.validateNotInShowdownRound();
+        this.validateNotInEndRound();
 
         const currentRound = this.game.currentRound;
 

--- a/pvm/ts/src/engine/actions/callAction.ts
+++ b/pvm/ts/src/engine/actions/callAction.ts
@@ -13,9 +13,10 @@ class CallAction extends BaseAction implements IAction {
         // Check base conditions (hand active, player's turn, player active)
         super.verify(player);
 
-        // 1. Round state check: Cannot call during ANTE or SHOWDOWN rounds
+        // 1. Round state check: Cannot call during ANTE, SHOWDOWN, or END rounds
         this.validateNotInAnteRound();
         this.validateNotInShowdownRound();
+        this.validateNotInEndRound();
 
         const currentRound = this.game.currentRound;
         // 2. Get the bets for the current round

--- a/pvm/ts/src/engine/actions/checkAction.ts
+++ b/pvm/ts/src/engine/actions/checkAction.ts
@@ -1,8 +1,7 @@
 import { PlayerActionType, TexasHoldemRound } from "@bitcoinbrisbane/block52";
 import { Player } from "../../models/player";
 import BaseAction from "./baseAction";
-import { IAction, Range, Turn } from "../types";
-import { BetManager } from "../managers/betManager";
+import { IAction, Range } from "../types";
 
 class CheckAction extends BaseAction implements IAction {
     get type(): PlayerActionType {
@@ -13,9 +12,10 @@ class CheckAction extends BaseAction implements IAction {
         // Basic validation
         super.verify(player);
 
-        // 1. Round state check: Cannot check in the ante or showdown rounds
+        // 1. Round state check: Cannot check in the ante, showdown, or end rounds
         this.validateNotInAnteRound();
         this.validateNotInShowdownRound();
+        this.validateNotInEndRound();
 
         const currentRound = this.game.currentRound;
 

--- a/pvm/ts/src/engine/actions/raiseAction.ts
+++ b/pvm/ts/src/engine/actions/raiseAction.ts
@@ -25,9 +25,10 @@ class RaiseAction extends BaseAction implements IAction {
         // 1. Perform basic validation (player active, player's turn, etc.)
         super.verify(player);
 
-        // 2. Cannot raise in the ANTE or SHOWDOWN rounds
+        // 1. Round state check: Cannot raise during ANTE, SHOWDOWN, or END rounds
         this.validateNotInAnteRound();
         this.validateNotInShowdownRound();
+        this.validateNotInEndRound();
 
         const currentRound = this.game.currentRound;
 

--- a/pvm/ts/tests/bugs.test.ts
+++ b/pvm/ts/tests/bugs.test.ts
@@ -26,6 +26,7 @@ import {
     test_1130,
     test_1130_edited,
     test_1137,
+    test_1158,
 } from "./scenarios/data";
 
 // This test suite is for the Texas Holdem game engine, specifically for the Ante round in a heads-up scenario.
@@ -428,6 +429,40 @@ describe("Texas Holdem - Data driven", () => {
 
             // After new hand, the game should reset for heads-up play
             expect(game.currentRound).toBe(TexasHoldemRound.ANTE);
+        });
+    });
+
+    describe("Bug 1158 - Sit and Go tournament not ending when only one player remains", () => {
+        let game: TexasHoldemGame;
+
+        beforeEach(() => {
+            game = fromTestJson(test_1158);
+        });
+
+        it("should end tournament when only one player remains", () => {
+            // Tournament should be in END state when only one player has chips
+            expect(game.currentRound).toEqual(TexasHoldemRound.END);
+
+            // Check that only one player has chips remaining
+            const playersWithChips = game.getSeatedPlayers().filter(player => player.chips > 0n);
+            expect(playersWithChips.length).toBe(1);
+
+            // Should have a winner declared
+            const gameState = game.toJson();
+            expect(gameState.winners).toBeDefined();
+            expect(gameState.winners.length).toBe(1);
+        });
+
+        it("should not allow further actions in completed tournament", () => {
+            // No legal actions should be available when tournament is complete
+            const remainingPlayer = game.getSeatedPlayers().find(player => player.chips > 0n);
+            expect(remainingPlayer).toBeDefined();
+
+            const legalActions = game.getLegalActions(remainingPlayer!.address);
+
+            // Only NEW_HAND action should be available to start a new tournament
+            expect(legalActions.length).toBe(1);
+            expect(legalActions[0].action).toBe("new-hand");
         });
     });
 });

--- a/pvm/ts/tests/scenarios/data.ts
+++ b/pvm/ts/tests/scenarios/data.ts
@@ -4932,3 +4932,100 @@ export const test_1137 = {
         "signature": "0x44a2eeaf6e0b9e7cd25fdabac75fe6564ec5f76284594ac3425a1c12d820e0221a7536df71add5ef4fcc24b84a6983cdfbba83db430b944a73f4d5e710243f381c"
     }
 }
+
+export const test_1158 = {
+    "id": "1158",
+    "result": {
+        "data": {
+            "type": "tournament",
+            "address": "0x22dfa2150160484310c5163f280f49e23b8fd34326",
+            "gameOptions": {
+                "minBuyIn": "10000000000000000000000",
+                "maxBuyIn": "10000000000000000000000",
+                "maxPlayers": 9,
+                "minPlayers": 2,
+                "smallBlind": "100000000000000000000",
+                "bigBlind": "200000000000000000000000",
+                "timeout": 300,
+                "type": "tournament"
+            },
+            "smallBlindPosition": 1,
+            "bigBlindPosition": 2,
+            "dealer": 9,
+            "players": [
+                {
+                    "address": "0xWINNER_ADDRESS_HERE",
+                    "seat": 1,
+                    "stack": "40000000000000000000000",
+                    "isSmallBlind": false,
+                    "isBigBlind": false,
+                    "isDealer": false,
+                    "deck": "AS-KH-AD-KS-2C-3H-4D-5S-6C-7H-8D-9S-TC-JH-QD-2H-3S-4C-5H-6D-7S-8C-9H-TD-JS-QC-AH-2D-3C-4S-5C-6H-7D-8S-9C-TH-JD-QS-AC-2S-3D-4H-5D-6S-7C-8H-9D-TC-JS-QH-AD-KD-KC",
+                    "holeCards": [],
+                    "status": "active",
+                    "legalActions": [
+                        {
+                            "action": "new-hand",
+                            "min": "0",
+                            "max": "0",
+                            "index": 1
+                        }
+                    ],
+                    "sumOfBets": "0",
+                    "timeout": 0,
+                    "signature": "0x0000000000000000000000000000000000000000000000000000000000000000"
+                },
+                {
+                    "address": "0xBUSTED_PLAYER_1",
+                    "seat": 2,
+                    "stack": "0",
+                    "isSmallBlind": false,
+                    "isBigBlind": false,
+                    "isDealer": false,
+                    "deck": "",
+                    "holeCards": [],
+                    "status": "busted",
+                    "legalActions": [],
+                    "sumOfBets": "0",
+                    "timeout": 0,
+                    "signature": "0x0000000000000000000000000000000000000000000000000000000000000000"
+                },
+                {
+                    "address": "0xBUSTED_PLAYER_2",
+                    "seat": 3,
+                    "stack": "0",
+                    "isSmallBlind": false,
+                    "isBigBlind": false,
+                    "isDealer": false,
+                    "deck": "",
+                    "holeCards": [],
+                    "status": "busted",
+                    "legalActions": [],
+                    "sumOfBets": "0",
+                    "timeout": 0,
+                    "signature": "0x0000000000000000000000000000000000000000000000000000000000000000"
+                }
+            ],
+            "communityCards": [],
+            "pots": ["0"],
+            "lastActedSeat": 0,
+            "currentPlayerId": "0x0000000000000000000000000000000000000000",
+            "handNumber": 15,
+            "actionCount": 100,
+            "previousActions": [],
+            "round": "end",
+            "winners": [
+                {
+                    "address": "0xWINNER_ADDRESS_HERE",
+                    "amount": "40000000000000000000000",
+                    "cards": [],
+                    "name": "Tournament Winner",
+                    "description": "Last Player Standing"
+                }
+            ],
+            "results": [],
+            "signature": "0x0000000000000000000000000000000000000000000000000000000000000000"
+        },
+        "signature": "0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Prevent betting, calling, checking, and raising during the End round.
  - Ensure Sit-and-Go ends when only one player remains; only starting a new hand is allowed afterward.

- Tests
  - Added regression test and scenario data to validate tournament end-state behavior and available actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->